### PR TITLE
Fix broken package installation

### DIFF
--- a/ribbon/pyproject.toml
+++ b/ribbon/pyproject.toml
@@ -12,7 +12,8 @@ authors = [
     "Paolo D'Onorio De Meo <paolo@paradigm.co>",
 ]
 packages = [
-    { include = 'abis' }
+    { include = 'abis' },
+    { include = 'ribbon' },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
When installing also "abis" as a package, we didn't notice that
poetry requires also the native package to be indicated.

> Using packages disables the package auto-detection feature
> meaning you have to explicitly specify the “default” package.

src: https://python-poetry.org/docs/pyproject/#packages