### PR TITLE
Fix relative path usage as a package

### DIFF
--- a/ribbon/ribbon/contract.py
+++ b/ribbon/ribbon/contract.py
@@ -12,6 +12,7 @@
 # Imports
 # ---------------------------------------------------------------------------
 import json
+from pathlib import Path
 from web3 import Web3
 
 from ribbon.chains import Chains
@@ -37,7 +38,12 @@ class ContractConnection:
         contract (object): Contract instance
     """
 
-    abi_location = 'abis/Swap.json'
+    abi_location = "abis/Swap.json"
+
+    @property
+    def abi_file_path(self):
+        # TODO: move in utils when we clean up the code
+        return Path(__file__).resolve().parent.parent / self.abi_location
 
     def __init__(self, config: ContractConfig):
         if config.chain_id not in Chains:
@@ -48,18 +54,18 @@ class ContractConnection:
 
         self.w3 = Web3(Web3.HTTPProvider(self.config.rpc_uri))
         if not self.w3.isConnected():
-            raise ValueError('RPC connection error')
+            raise ValueError("RPC connection error")
 
         chain = self.config.chain_id
         rpc_chain_id = self.w3.eth.chain_id
         if int(rpc_chain_id) != chain.value:
             raise ValueError(
-                f'RPC chain mismatched ({rpc_chain_id}). '
-                + f'Expected: {chain.name} '
-                + f'({chain.value})'
+                f"RPC chain mismatched ({rpc_chain_id}). "
+                + f"Expected: {chain.name} "
+                + f"({chain.value})"
             )
 
-        with open(self.abi_location) as f:
+        with open(self.abi_file_path) as f:
             abi = json.load(f)
 
         self.contract = self.w3.eth.contract(self.address, abi=abi)


### PR DESCRIPTION
The relative path used for loading the `abis` 
does not work when the code is being used as a package.

Add a `Pathlib` approach in the contract to solve.