### PR TITLE
Allow both public and private key arguments for the Wallet object

### DIFF
--- a/ribbon/README.md
+++ b/ribbon/README.md
@@ -81,7 +81,7 @@ payload = Bid(
 )
 
 
-wallet = Wallet(wallet_private_key)
+wallet = Wallet(public_key=wallet_public_key, private_key=wallet_private_key)
 
 bid = wallet.sign_bid(domain, payload)
 pprint(asdict(bid))
@@ -182,6 +182,9 @@ print(jwtSignature)
 
 To contribute to this package you may set up a dedicated container:
 ```bash
+$ pwd
+[...]/sdks/ribbon
+
 # open a container with python
 $ docker run -it --rm \
     -v $(pwd):/tmp/code -w /tmp/code \
@@ -190,7 +193,7 @@ $ docker run -it --rm \
     bash
 
 # install the library in development mode
-pip3 install -e ribbon/
+pip3 install -e /code
 
 # run code that accesses the ribbon sdk
 python3 my_examples.py

--- a/ribbon/ribbon/wallet.py
+++ b/ribbon/ribbon/wallet.py
@@ -43,15 +43,24 @@ class Wallet:
     Object to generate bid signature
 
     Args:
-        privateKey (str): Private key of the user in hex format with 0x prefix
+        public_key (str): Public key of the user in hex format with 0x prefix
+        private_key (str): Private key of the user in hex format with 0x prefix
 
     Attributes:
         signer (object): Instance of signer to generate signature
     """
 
-    def __init__(self, privateKey: str) -> None:
-        self.signer = eth_keys.keys.PrivateKey(bytes.fromhex(privateKey[2:]))
-        self.address = get_address(self.signer.public_key.to_address())
+    def __init__(self, public_key: str = None, private_key: str = None):
+        if not private_key and not public_key:
+            raise ValueError("Can't instanciate a Wallet without a public or private key")
+
+        self.private_key = private_key
+        self.public_key = public_key
+
+        if self.private_key:
+            self.signer = eth_keys.keys.PrivateKey(bytes.fromhex(self.private_key[2:]))
+            if not self.public_key:
+                self.public_key = get_address(self.signer.public_key.to_address())
 
     def sign_msg(self, messageHash: str) -> dict:
         """Sign a hash message using the signer object
@@ -107,10 +116,13 @@ class Wallet:
         if not isinstance(bid, Bid):
             raise TypeError("Invalid bid")
 
+        if not self.private_key:
+            raise ValueError("Unable to sign. Create the Wallet with the private key argument.")
+
         signerWallet = get_address(bid.signerWallet)
         referrer = get_address(bid.referrer)
 
-        if signerWallet != self.address:
+        if signerWallet != self.public_key:
             raise ValueError("Signer wallet address mismatch")
 
         signature = self._sign_type_data_v4(domain, asdict(bid), types)
@@ -145,7 +157,7 @@ class Wallet:
         bidding_token = ERC20Contract(token_config)
 
         allowance = (
-            bidding_token.get_allowance(self.address, swap_config.address)
+            bidding_token.get_allowance(self.public_key, swap_config.address)
             / bidding_token.decimals
         )
 


### PR DESCRIPTION
The current SDK requires only a private key for creating and using
the wallet object, which is also used to verify the allowance.

This conflicts with the original idea for Paradigm that makers would
provide only the public key when adding their credentials to the admin
page, thus only the public key would be available when verifying the
allowance.

Proposing here an alternative implementation:
* having both private and public key as optional arguments in the wallet
object
* raise an error when creating the wallet object if both are missing
* derive the public key from the private one only, if the private one
is available
* raise an error in sign_bid if the private key was not provided