### PR TITLE
Enforced max-doc-length 72 and added markdownlint to precommit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,7 +11,7 @@ exclude =
 max-complexity = 20
 max-line-length = 99
 # based on https://www.python.org/dev/peps/pep-0008/#maximum-line-length
-max-doc-length = 80
+max-doc-length = 72
 
 ignore = E203,W503,W605
 # E203 needed for black, see https://github.com/psf/black/issues/315

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,7 @@ repos:
   rev: 4.0.1
   hooks:
   - id: flake8
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.30.0
+  hooks:
+  - id: markdownlint

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ currently integrating with "Paradigm Co.".
 ## Development
 
 To contribute to this package you may set up a dedicated container:
+
 ```bash
 $ git clone git@github.com:tradeparadigm/sdks.git
 $ cd ribbon
@@ -37,5 +38,5 @@ To improve quality and readibility of code,
 please make sure to use `pre-commit` hooks.
 
 Either execute `pre-commit run` before pushing the final version of your
-pull request, or `pre-commit install` to have automatic checks before 
+pull request, or `pre-commit install` to have automatic checks before
 each commit.

--- a/friktion/README.md
+++ b/friktion/README.md
@@ -1,34 +1,42 @@
 # Friktion Swap Client for Paradigm IntegrationCancel changes
 
-This python SDK enables interaction with the on-chain Friktion swap program. This includes the ability to create, retrieve, and execute a swap order. The swap order represents the exchange of 2 assets in prerecorded static amounts.
-
+This python SDK enables interaction with the on-chain Friktion swap program.
+This includes the ability to create, retrieve, and execute a swap order. The
+swap order represents the exchange of 2 assets in prerecorded static amounts.
 
 ## Setup
 
-0. look at ../README.md (top-level in this repo), install all dependencies described there (solana + anchor)
+0. look at ../README.md (top-level in this repo), install all dependencies
+    described there (solana + anchor)
 1. ```poetry install```
 2. ```poetry shell```
-3. set ANCHOR_PROVIDER_URL (rpc url) and ANCHOR_WALLET (file that has keypair of wallet) bash env variables (export them in terminal)
+3. set ANCHOR_PROVIDER_URL (rpc url) and ANCHOR_WALLET (file that has keypair
+    of wallet) bash env variables (export them in terminal)
       (NOTE: ANCHOR_PROVIDER_URL determines if devnet, testnet, mainnet, etc)
       (NOTE: make sure you have SOL in the ANCHOR_WALLET for the correct cluster)
-
-Example for step #3:
-     ```export ANCHOR_PROVIDER_URL=https://api.devnet.solana.com```
-     ```export ANCHOR_WALLET=~/.config/solana/id.json```
+    Example for step #3:
+         ```export ANCHOR_PROVIDER_URL=https://api.devnet.solana.com```
+         ```export ANCHOR_WALLET=~/.config/solana/id.json```
 
 4. ```solana-keygen pubkey $ANCHOR_WALLET | xargs solana airdrop 1```
-5. ensure you have devnet tokens for the GIVE_MINT and RECEIVE_MINT specified at the top of ```main.py```
+5. ensure you have devnet tokens for the GIVE_MINT and RECEIVE_MINT specified at
+    the top of ```main.py```
 
 ## Testing
 
-The following command will run a script that 1. creates an offer 2. fetches the offer (and asserts that it is available to execute), 3. fills the offer with a corresponding bid
+The following command will run a script that 1. creates an offer 2. fetches the
+offer (and asserts that it is available to execute), 3. fills the offer with a
+corresponding bid
+
 ```cd friktion && python3 main.py```
 
 ## Basic Usage
 
-```main.py``` should be used as a reference whenever possible. However, if it is not available below are some samples of python code using the SDK.
+```main.py``` should be used as a reference whenever possible. However, if it is
+not available below are some samples of python code using the SDK.
 
-**Creating Offer**
+### Creating Offer
+
 ```python
 offer_1 = await c.create_offer(
         wallet, SwapOrderTemplate(
@@ -43,14 +51,16 @@ offer_1 = await c.create_offer(
     )
 ```
 
-**Retrieving Offer**
+### Retrieving Offer
+
 ```python
 offer_2 = await c.get_offer_details(
         wallet.public_key, offer_1.order_id
     )
 ```
 
-**Executing Bid**
+### Executing Bid
+
 ```python
 await c.validate_and_exec_bid(
         wallet, BidDetails(
@@ -60,7 +70,6 @@ await c.validate_and_exec_bid(
         )
     )
 ```
-
 
 ## Swap Order Struct Layout
 

--- a/opyn/README.md
+++ b/opyn/README.md
@@ -134,7 +134,7 @@ print(result)
 
 Example output
 
-```
+```python
 {
     'errors': 4,
     'messages': [
@@ -192,7 +192,7 @@ print(check)
 
 - Make sure to have the following environment variables in `.env` file:
 
-```
+```bash
 RPC_TOKEN=
 RPC_URL=
 MAKER_PubKEY=

--- a/opyn/opyn/config.py
+++ b/opyn/opyn/config.py
@@ -83,7 +83,7 @@ class OpynSDKConfig(SDKConfig):
         config = ContractConfig(address=contract_address, chain_id=chain_id, rpc_uri=rpc_uri)
         swap_contract = SettlementContract(config)
 
-        # This is expected to fail, BidData currently has a different signature
+        # Expected to fail: BidData currently has a different signature
         signed_bid = BidData(
             swapId=swap_id,
             nonce=nonce,

--- a/opyn/opyn/definitions.py
+++ b/opyn/opyn/definitions.py
@@ -48,7 +48,9 @@ class MessageToSign:
 
 @dataclass
 class BidData:
-    """Bid data to send on-chain containing bid information and signature"""
+    """
+    Bid data to send on-chain containing bid information and signature
+    """
 
     offerId: int
     bidId: int

--- a/opyn/opyn/erc20.py
+++ b/opyn/opyn/erc20.py
@@ -40,8 +40,10 @@ class ERC20Contract(ContractConnection):
         Method to get allowance of owner
 
         Args:
-            owner (str): Address of owner's address e.g. user wallet address
-            spender (str): Address of spender's address e.g. the Swap contract
+            owner (str): Address of owner's address
+                         e.g. user wallet address
+            spender (str): Address of spender's address
+                           e.g. the Swap contract
 
         Raises:
             ValueError: Address of wallet is invalid
@@ -61,7 +63,8 @@ class ERC20Contract(ContractConnection):
         Method to get balance of owner
 
         Args:
-            owner (str): Address of owner's address e.g. user wallet address
+            owner (str): Address of owner's address
+                         e.g. user wallet address
 
         Raises:
             ValueError: Address of wallet is invalid

--- a/opyn/opyn/settlement.py
+++ b/opyn/opyn/settlement.py
@@ -38,12 +38,12 @@ class SettlementContract(ContractConnection):
         Method to create offer
 
         Args:
-            offer (dict): Offer dictionary containing necessary parameters
-                to create a new offer
+            offer (dict): Offer dictionary containing necessary
+                parameters to create a new offer
             wallet (Wallet): Wallet class instance
 
         Raises:
-            TypeError: Offer argument is not a valid instance of Offer class
+            TypeError: Offer argument is not an Offer class instance
             ExecError: Transaction reverted
 
         Returns:
@@ -110,15 +110,16 @@ class SettlementContract(ContractConnection):
         Method to validate bid
 
         Args:
-            bid (dict): Bid dictionary containing offerId, bidId, signerAddress,
-            bidderAddress, bidToken, offerToken, bidAmount, sellAmount, v, r, s
+            bid (dict): Bid dictionary containing offerId, bidId,
+            signerAddress, bidderAddress, bidToken, offerToken,
+            bidAmount, sellAmount, v, r, s
 
         Raises:
             TypeError: Bid argument is not an instance of SignedBid
 
         Returns:
-            response (dict): Dictionary containing number of errors (errors)
-            and the corresponding error messages (messages)
+            response (dict): Dictionary containing number of errors
+            and the corresponding error messages
         """
         if not isinstance(bid, BidData):
             raise TypeError("Invalid signed bid")

--- a/opyn/opyn/wallet.py
+++ b/opyn/opyn/wallet.py
@@ -54,8 +54,10 @@ class Wallet:
     Object to generate bid signature
 
     Args:
-        public_key (str): Public key of the user in hex format with 0x prefix
-        private_key (str): Private key of the user in hex format with 0x prefix
+        public_key (str): Public key of the user
+                          in hex format with 0x prefix
+        private_key (str): Private key of the user
+                           in hex format with 0x prefix
 
     Attributes:
         signer (object): Instance of signer to generate signature
@@ -79,8 +81,9 @@ class Wallet:
         """Sign a bid using py_eth_sig_utils
 
         Args:
-            domain (dict): Dictionary containing domain parameters including
-              name, version, chainId, verifyingContract
+            domain (dict): Dictionary containing domain parameters
+                           including name, version, chainId,
+                           verifyingContract
             message_to_sign (MessageToSign): Unsigned Order Data
 
         Raises:
@@ -130,7 +133,8 @@ class Wallet:
         """Verify wallet's allowance for a given token
 
         Args:
-            config (ContractConfig): Configuration to setup the Swap Contract
+            config (ContractConfig): Configuration to setup the
+                                     Swap Contract
             token_address (str): Address of token
 
         Returns:
@@ -155,7 +159,8 @@ class Wallet:
         Args:
             settlement_config (ContractConfig): Configuration to setup
                                                 the Settlement contract
-            token_address (str): Address of token to increase allowance of
+            token_address (str): Address of token to which increase
+                                 the allowance
             amount (str): Amount to increase allowance to
         """
         token_config = ContractConfig(

--- a/ribbon/README.md
+++ b/ribbon/README.md
@@ -2,7 +2,7 @@
 
 Python SDK to interact with Ribbon Finance's systems.
 
-Website: https://www.ribbon.finance
+Website: <https://www.ribbon.finance>
 
 ## Install
 
@@ -25,6 +25,7 @@ There are different things you are able to do with this package.
 First let's setup the needed informations.
 
 This is an example of how we can define your domain of interaction:
+
 ```python
 from ribbon.definitions import Chains, ContractConfig, Domain
 from ribbon.swap import SwapContract, asdict
@@ -53,6 +54,7 @@ print(asdict(domain))
 ```
 
 This may output something similar to:
+
 ```python
 {'chainId': 42,
  'name': 'RIBBON SWAP',
@@ -88,6 +90,7 @@ pprint(asdict(bid))
 ```
 
 This may output something similar to:
+
 ```python
 {'buyAmount': 1000000000000000000,
  'nonce': 1,
@@ -135,6 +138,7 @@ print(check)
 ### Informations about the option (oToken)
 
 Get details related to the oToken of interest:
+
 ```python
 from ribbon.otoken import oTokenContract
 
@@ -147,6 +151,7 @@ print(details)
 ```
 
 This may output something similar to:
+
 ```python
 {'collateralAsset': '0xd0A1E359811322d97991E03f863a0C30C2cF029C',
  'expiryTimestamp': 1646380800,
@@ -157,6 +162,7 @@ This may output something similar to:
 ```
 
 To get details of an offer instead:
+
 ```python
 offer_id = 3
 
@@ -165,9 +171,11 @@ print(offer_details)
 ```
 
 ### Create an offer
+
 To create a new offer in the swap contract:
 (This method requires the wallet to have sufficient ETH to send the transaction)
-```
+
+```python
 new_offer = Offer(
     oToken='0x61FB6d86456Dc4821f0738fDFD478B281294932D',
     biddingToken='0xd0A1E359811322d97991E03f863a0C30C2cF029C',

--- a/ribbon/ribbon/encode.py
+++ b/ribbon/ribbon/encode.py
@@ -121,11 +121,11 @@ class TypedDataEncoder:
 
     Attributes:
         types (dict): Instance of signer to generate signature
-        _encoderCache (dict): Dictionary container to cache encoder
-        _types (dict): Dictionary container to cache struct names
-        links (dict): Dictionary container to store links between structs
-        parents (dict): Dictionary container to store parent of structs
-        subtypes (dict): Dictionary container to check circular reference
+        _encoderCache (dict): Dictionary to cache encoder
+        _types (dict): Dictionary to cache struct names
+        links (dict): Dictionary to store links between structs
+        parents (dict): Dictionary to store parent of structs
+        subtypes (dict): Dictionary to check circular reference
         primaryType (dict): Primary type to encode
     """
 
@@ -292,7 +292,8 @@ class TypedDataEncoder:
 
     def hash(self, value: dict) -> str:
         """
-        Generate the hash of encoded data for the primary type given a value
+        Generate the hash of encoded data for the primary type
+        of the given a value
 
         Args:
             value (dict): Values corresponding to the primary type

--- a/ribbon/ribbon/erc20.py
+++ b/ribbon/ribbon/erc20.py
@@ -40,8 +40,10 @@ class ERC20Contract(ContractConnection):
         Method to get allowance of owner
 
         Args:
-            owner (str): Address of owner's address e.g. user wallet address
-            spender (str): Address of spender's address e.g. the Swap contract
+            owner (str): Address of owner's address
+                         e.g. user wallet address
+            spender (str): Address of spender's address
+                         e.g. the Swap contract
 
         Raises:
             ValueError: Address of wallet is invalid
@@ -61,7 +63,8 @@ class ERC20Contract(ContractConnection):
         Method to get balance of owner
 
         Args:
-            owner (str): Address of owner's address e.g. user wallet address
+            owner (str): Address of owner's address
+                         e.g. user wallet address
 
         Raises:
             ValueError: Address of wallet is invalid

--- a/ribbon/ribbon/swap.py
+++ b/ribbon/ribbon/swap.py
@@ -92,15 +92,16 @@ class SwapContract(ContractConnection):
         Method to validate bid
 
         Args:
-            bid (dict): Bid dictionary containing swapId, nonce, signerWallet,
-              sellAmount, buyAmount, referrer, v, r, and s
+            bid (dict): Bid dictionary containing swapId, nonce,
+                        signerWallet, sellAmount, buyAmount,
+                        referrer, v, r, and s
 
         Raises:
             TypeError: Bid argument is not an instance of SignedBid
 
         Returns:
-            response (dict): Dictionary containing number of errors (errors)
-              and the corresponding error messages (messages)
+            response (dict): Dictionary containing number of errors
+              and the corresponding error messages
         """
         if not isinstance(bid, SignedBid):
             raise TypeError("Invalid signed bid")
@@ -142,12 +143,12 @@ class SwapContract(ContractConnection):
         Method to create offer
 
         Args:
-            offer (dict): Offer dictionary containing necessary parameters
-                to create a new offer
+            offer (dict): Offer dictionary containing necessary
+                          parameters to create a new offer
             wallet (Wallet): Wallet class instance
 
         Raises:
-            TypeError: Offer argument is not a valid instance of Offer class
+            TypeError: Offer argument is not an Offer class instance
             ExecError: Transaction reverted
 
         Returns:

--- a/ribbon/ribbon/wallet.py
+++ b/ribbon/ribbon/wallet.py
@@ -44,8 +44,10 @@ class Wallet:
     Object to generate bid signature
 
     Args:
-        public_key (str): Public key of the user in hex format with 0x prefix
-        private_key (str): Private key of the user in hex format with 0x prefix
+        public_key (str): Public key of the user
+                          in hex format with 0x prefix
+        private_key (str): Private key of the user
+                           in hex format with 0x prefix
 
     Attributes:
         signer (object): Instance of signer to generate signature
@@ -67,7 +69,8 @@ class Wallet:
         """Sign a hash message using the signer object
 
         Args:
-            messageHash (str): Message to signed in hex format with 0x prefix
+            messageHash (str): Message to be signed
+                               in hex format with 0x prefix
 
         Returns:
             signature (dict): Signature split into v, r, s components
@@ -85,13 +88,14 @@ class Wallet:
         https://eips.ethereum.org/EIPS/eip-712
 
         Args:
-            domain (dict): Dictionary containing domain parameters including
-              name, version, chainId, verifyingContract and salt (optional)
+            domain (dict): Dictionary containing domain parameters
+                           including name, version, chainId,
+                           verifyingContract and salt (optional)
             types (dict): Dictionary of types and their fields
             value (dict): Dictionary of values for each field in types
 
         Raises:
-            TypeError: Domain argument is not an instance of Domain class
+            TypeError: Domain argument is not a Domain class instance
 
         Returns:
             signature (dict): Signature split into v, r, s components
@@ -107,8 +111,9 @@ class Wallet:
         """Sign a bid using _sign_type_data_v4
 
         Args:
-            domain (dict): Dictionary containing domain parameters including
-              name, version, chainId, verifyingContract and salt (optional)
+            domain (dict): Dictionary containing domain parameters
+                           including name, version, chainId,
+                           verifyingContract and salt (optional)
             types (dict): Dictionary of types and their fields
             bid (dict): Dicionary of bid specification
 
@@ -148,7 +153,8 @@ class Wallet:
         """Verify wallet's allowance for a given token
 
         Args:
-            config (ContractConfig): Configuration to setup the Swap Contract
+            config (ContractConfig): Configuration to setup
+                                     the Swap Contract
             token_address (str): Address of token
 
         Returns:

--- a/template/template/swap.py
+++ b/template/template/swap.py
@@ -46,15 +46,16 @@ class SwapContract:
         Method to validate bid
 
         Args:
-            bid (dict): Bid dictionary containing swapId, nonce, signerWallet,
-              sellAmount, buyAmount, referrer, v, r, and s
+            bid (dict): Bid dictionary containing swapId, nonce,
+                        signerWallet, sellAmount, buyAmount,
+                        referrer, v, r, and s
 
         Raises:
             TypeError: Bid argument is not an instance of SignedBid
 
         Returns:
-            response (dict): Dictionary containing number of errors (errors)
-              and the corresponding error messages (messages)
+            response (dict): Dictionary containing number of errors
+              and the corresponding error messages
         """
         if not isinstance(bid, SignedBid):
             raise TypeError("Invalid signed bid")
@@ -67,12 +68,12 @@ class SwapContract:
         Method to create offer
 
         Args:
-            offer (dict): Offer dictionary containing necessary parameters
-                to create a new offer
+            offer (dict): Offer dictionary containing necessary
+                          parameters to create a new offer
             wallet (Wallet): Wallet class instance
 
         Raises:
-            TypeError: Offer argument is not a valid instance of Offer class
+            TypeError: Offer argument is an Offer class instance
             ExecError: Transaction reverted
 
         Returns:

--- a/template/template/wallet.py
+++ b/template/template/wallet.py
@@ -7,8 +7,10 @@ class Wallet:
     Object to generate bid signature
 
     Args:
-        public_key (str): Public key of the user in hex format with 0x prefix
-        private_key (str): Private key of the user in hex format with 0x prefix
+        public_key (str): Public key of the user
+                          in hex format with 0x prefix
+        private_key (str): Private key of the user
+                           in hex format with 0x prefix
 
     Attributes:
         signer (object): Instance of signer to generate signature
@@ -23,7 +25,8 @@ class Wallet:
         """Verify wallet's allowance for a given token
 
         Args:
-            config (ContractConfig): Configuration to setup the Swap Contract
+            config (ContractConfig): Configuration to setup
+                                    the Swap Contract
             token_address (str): Address of token
 
         Returns:

--- a/tests/base.py
+++ b/tests/base.py
@@ -64,10 +64,10 @@ class TestsBase:
         """
         These checks are needed because abc
         does no checks on arguments of concrete implementations
-        This metodo verifies the method signature:
-          - all parameters should correspond to parameters on the reference
-          - exception: additional parameters with a default value are allowed
-          - all methods are expected to accept *args and **kwargs
+        This utility verifies the method signature:
+          - all params should correspond to params on the reference
+          - additional params with a default value are allowed
+          - all methods are expected to accept **kwargs
         """
 
         method_signature = signature(method).parameters


### PR DESCRIPTION
Enforced max-doc-length to 72 chars
as suggested by PEP8 specifications

Added markdownlint to precommit configuration
to detect style errors in markdown

Fixed markdown errors