### PR TITLE
Adding Friktion SDK interface

### DIFF
--- a/.github/workflows/test_sdks.yml
+++ b/.github/workflows/test_sdks.yml
@@ -28,8 +28,7 @@ jobs:
         run: |
           # TODO: move me in a requirements file
           pip install pytest
-          # TODO: add ./friktion
-          pip install ./sdk_commons ./template ./opyn ./ribbon
+          pip install ./sdk_commons ./template ./opyn ./friktion ./ribbon
 
       - name: Run pytest
         run: |

--- a/friktion/friktion/config.py
+++ b/friktion/friktion/config.py
@@ -94,7 +94,6 @@ class FriktionSDKConfig(SDKConfig):
         details: Offer = async_to_sync(swap_contract.get_offer_details)(
             PublicKey(seller), offer_id
         )
-        # TODO: enforce specific types on OfferDetails
         return {
             'seller': str(details.seller),
             'biddingToken': str(details.biddingToken),

--- a/friktion/friktion/config.py
+++ b/friktion/friktion/config.py
@@ -1,12 +1,14 @@
+from typing import Any
+
 from asgiref.sync import async_to_sync
 from solana.publickey import PublicKey
 from spl.token.instructions import get_associated_token_address
 
-from friktion.friktion_anchor.accounts.swap_order import SwapOrder
+# from friktion.friktion_anchor.accounts.swap_order import SwapOrder
 from friktion.offer import Offer
 from friktion.swap import Network, SwapContract
 from sdk_commons.chains import Chains
-from sdk_commons.config import SDKConfig
+from sdk_commons.config import BidValidation, OfferDetails, OfferTokenDetails, SDKConfig
 
 
 class AuthorizationPages:
@@ -37,13 +39,18 @@ class FriktionSDKConfig(SDKConfig):
         offer_amount: int,
         public_key: str,
         private_key: str,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> str:
         """Create an offer"""
 
-        swap_order = SwapOrder(...)
-        Offer.from_swap_order(swap_order=swap_order, address=PublicKey(public_key))
-        ...
+        # swap_order = SwapOrder(...)
+        # Offer.from_swap_order(
+        #     swap_order=swap_order,
+        #     address=PublicKey(public_key)
+        # )
+
+        return "not-implemented-yet"
 
     def get_otoken_details(
         self,
@@ -52,13 +59,14 @@ class FriktionSDKConfig(SDKConfig):
         rpc_uri: str,
         offer_id: int,
         seller: str,
-        **kwargs,
-    ) -> dict:
+        *args: Any,
+        **kwargs: Any,
+    ) -> OfferTokenDetails:
         """Return details about the offer token"""
 
-        network = self.CHAIN_NETWORK_MAP[chain_id]
+        network = self.CHAIN_NETWORK_MAP[Chains(chain_id)]
         swap_contract = SwapContract(network)
-        details = async_to_sync(swap_contract.get_offered_token_details)(
+        details: OfferTokenDetails = async_to_sync(swap_contract.get_offered_token_details)(
             PublicKey(seller), offer_id
         )
 
@@ -71,23 +79,26 @@ class FriktionSDKConfig(SDKConfig):
         rpc_uri: str,
         offer_id: int,
         seller: str,
-        **kwargs,
-    ) -> dict:
+        *args: Any,
+        **kwargs: Any,
+    ) -> OfferDetails:
         """Return details for a given offer"""
 
-        network = self.CHAIN_NETWORK_MAP[chain_id]
+        network = self.CHAIN_NETWORK_MAP[Chains(chain_id)]
         swap_contract = SwapContract(network)
 
         details: Offer = async_to_sync(swap_contract.get_offer_details)(
             PublicKey(seller), offer_id
         )
+        # TODO: enforce specific types on OfferDetails
         return {
             'seller': str(details.seller),
-            'bidding_token': str(details.biddingToken),
-            'min_price': details.minPrice,
-            'min_bid_size': details.minBidSize,
-            'total_size': details.offerAmount,
-            'offered_token': str(details.oToken),
+            'biddingToken': str(details.biddingToken),
+            'minPrice': str(details.minPrice),
+            'minBidSize': str(details.minBidSize),
+            'totalSize': str(details.offerAmount),
+            'oToken': str(details.oToken),
+            'availableSize': "???",
         }
 
     def validate_bid(
@@ -102,11 +113,12 @@ class FriktionSDKConfig(SDKConfig):
         buy_amount: int,
         referrer: str,
         signature: str,
-        **kwargs,
-    ) -> str:
+        *args: Any,
+        **kwargs: Any,
+    ) -> BidValidation:
         """Validate the signing bid"""
 
-        return None
+        return {'errors': 0}
 
     def verify_allowance(
         self,
@@ -115,14 +127,15 @@ class FriktionSDKConfig(SDKConfig):
         rpc_uri: str,
         public_key: str,
         token_address: str,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> bool:
         """
         Verify if the contract is allowed to access
         the given token on the wallet
         """
 
-        network = self.CHAIN_NETWORK_MAP[chain_id]
+        network = self.CHAIN_NETWORK_MAP[Chains(chain_id)]
         swap_contract = SwapContract(network)
 
         token_account = get_associated_token_address(

--- a/friktion/friktion/config.py
+++ b/friktion/friktion/config.py
@@ -1,0 +1,143 @@
+from enum import Enum
+
+from asgiref.sync import async_to_sync
+from solana.publickey import PublicKey
+from spl.token.instructions import get_associated_token_address
+
+from friktion.friktion_anchor.accounts.swap_order import SwapOrder
+from friktion.offer import Offer
+from friktion.swap import Network, SwapContract
+from sdk_commons.config import SDKConfig
+
+
+class AuthorizationPages:
+    # TODO: add when we get the UI for both
+    mainnet = "https://notdefined.yet/auctions/"
+    testnet = "https://notdefined.yet/auctions/"
+
+
+# TODO: remove me
+class Chains(Enum):
+    SOLANA_DEV = 777777
+    SOLANA_MAIN = 888888
+
+
+class FriktionSDKConfig(SDKConfig):
+
+    authorization_pages = AuthorizationPages
+    # TODO: replace with:
+    # supported_chains = [Chains.SOLANA_DEV]
+    venue_chains = Chains
+
+    CHAIN_NETWORK_MAP = {
+        Chains.SOLANA_DEV: Network.DEVNET,
+        Chains.SOLANA_MAIN: Network.MAINNET,
+    }
+
+    def create_offer(
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        oToken: str,
+        bidding_token: str,
+        min_price: int,
+        min_bid_size: int,
+        offer_amount: int,
+        public_key: str,
+        private_key: str,
+        **kwargs,
+    ) -> str:
+        """Create an offer"""
+
+        swap_order = SwapOrder(...)
+        Offer.from_swap_order(swap_order=swap_order, address=PublicKey(public_key))
+        ...
+
+    def get_otoken_details(
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        offer_id: int,
+        seller: str,
+        **kwargs,
+    ) -> dict:
+        """Return details about the offer token"""
+
+        network = self.CHAIN_NETWORK_MAP[chain_id]
+        swap_contract = SwapContract(network)
+        details = async_to_sync(swap_contract.get_offered_token_details)(
+            PublicKey(seller), offer_id
+        )
+
+        return details
+
+    def get_offer_details(
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        offer_id: int,
+        seller: str,
+        **kwargs,
+    ) -> dict:
+        """Return details for a given offer"""
+
+        network = self.CHAIN_NETWORK_MAP[chain_id]
+        swap_contract = SwapContract(network)
+
+        details: Offer = async_to_sync(swap_contract.get_offer_details)(
+            PublicKey(seller), offer_id
+        )
+        return {
+            'seller': str(details.seller),
+            'bidding_token': str(details.biddingToken),
+            'min_price': details.minPrice,
+            'min_bid_size': details.minBidSize,
+            'total_size': details.offerAmount,
+            'offered_token': str(details.oToken),
+        }
+
+    def validate_bid(
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        swap_id: int,
+        nonce: int,
+        signer_wallet: str,
+        sell_amount: int,
+        buy_amount: int,
+        referrer: str,
+        v: int,
+        r: str,
+        s: str,
+        **kwargs,
+    ) -> str:
+        """Validate the signing bid"""
+
+        return None
+
+    def verify_allowance(
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        public_key: str,
+        token_address: str,
+        **kwargs,
+    ) -> bool:
+        """
+        Verify if the contract is allowed to access
+        the given token on the wallet
+        """
+
+        network = self.CHAIN_NETWORK_MAP[chain_id]
+        swap_contract = SwapContract(network)
+
+        token_account = get_associated_token_address(
+            PublicKey(public_key), PublicKey(token_address)
+        )
+
+        return swap_contract.verify_allowance(PublicKey(token_address), token_account)

--- a/friktion/friktion/config.py
+++ b/friktion/friktion/config.py
@@ -1,5 +1,3 @@
-from enum import Enum
-
 from asgiref.sync import async_to_sync
 from solana.publickey import PublicKey
 from spl.token.instructions import get_associated_token_address
@@ -7,6 +5,7 @@ from spl.token.instructions import get_associated_token_address
 from friktion.friktion_anchor.accounts.swap_order import SwapOrder
 from friktion.offer import Offer
 from friktion.swap import Network, SwapContract
+from sdk_commons.chains import Chains
 from sdk_commons.config import SDKConfig
 
 
@@ -16,18 +15,10 @@ class AuthorizationPages:
     testnet = "https://notdefined.yet/auctions/"
 
 
-# TODO: remove me
-class Chains(Enum):
-    SOLANA_DEV = 777777
-    SOLANA_MAIN = 888888
-
-
 class FriktionSDKConfig(SDKConfig):
 
     authorization_pages = AuthorizationPages
-    # TODO: replace with:
-    # supported_chains = [Chains.SOLANA_DEV]
-    venue_chains = Chains
+    supported_chains = [Chains.SOLANA_DEV]
 
     CHAIN_NETWORK_MAP = {
         Chains.SOLANA_DEV: Network.DEVNET,

--- a/friktion/friktion/config.py
+++ b/friktion/friktion/config.py
@@ -101,9 +101,7 @@ class FriktionSDKConfig(SDKConfig):
         sell_amount: int,
         buy_amount: int,
         referrer: str,
-        v: int,
-        r: str,
-        s: str,
+        signature: str,
         **kwargs,
     ) -> str:
         """Validate the signing bid"""

--- a/friktion/friktion/config.py
+++ b/friktion/friktion/config.py
@@ -97,6 +97,8 @@ class FriktionSDKConfig(SDKConfig):
         return {
             'seller': str(details.seller),
             'biddingToken': str(details.biddingToken),
+            # NOTE: it is not a Decimal at this point
+            # as we still have to apply the resolution.
             'minPrice': str(details.minPrice),
             'minBidSize': Decimal(details.minBidSize),
             'totalSize': Decimal(details.offerAmount),

--- a/friktion/friktion/config.py
+++ b/friktion/friktion/config.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Any
 
 from asgiref.sync import async_to_sync
@@ -94,8 +95,8 @@ class FriktionSDKConfig(SDKConfig):
             'seller': str(details.seller),
             'biddingToken': str(details.biddingToken),
             'minPrice': str(details.minPrice),
-            'minBidSize': str(details.minBidSize),
-            'totalSize': str(details.offerAmount),
+            'minBidSize': Decimal(details.minBidSize),
+            'totalSize': Decimal(details.offerAmount),
             'oToken': str(details.oToken),
             'availableSize': "???",
         }

--- a/friktion/friktion/config.py
+++ b/friktion/friktion/config.py
@@ -12,9 +12,8 @@ from sdk_commons.config import BidValidation, OfferDetails, OfferTokenDetails, S
 
 
 class AuthorizationPages:
-    # TODO: add when we get the UI for both
-    mainnet = "https://notdefined.yet/auctions/"
-    testnet = "https://notdefined.yet/auctions/"
+    mainnet = "https://app.friktion.fi/approve"
+    testnet = "https://devnet.friktion.fi/approve"
 
 
 class FriktionSDKConfig(SDKConfig):

--- a/friktion/friktion/config.py
+++ b/friktion/friktion/config.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from asgiref.sync import async_to_sync
 from solana.publickey import PublicKey
-from spl.token.instructions import get_associated_token_address
 
 from friktion.bid_details import BidDetails
 from friktion.offer import Offer
@@ -164,8 +163,7 @@ class FriktionSDKConfig(SDKConfig):
         network = self.CHAIN_NETWORK_MAP[Chains(chain_id)]
         swap_contract = SwapContract(network)
 
-        token_account = get_associated_token_address(
-            PublicKey(public_key), PublicKey(token_address)
+        return swap_contract.verify_allowance(
+            PublicKey(token_address),
+            PublicKey(public_key),
         )
-
-        return swap_contract.verify_allowance(PublicKey(token_address), token_account)

--- a/friktion/friktion/swap.py
+++ b/friktion/friktion/swap.py
@@ -29,6 +29,7 @@ from friktion.friktion_anchor.instructions import cancel, claim
 from friktion.inertia_anchor.accounts import OptionsContract
 from friktion.offer import Offer
 from friktion.pda import DELEGATE_AUTHORITY_ADDRESS, SwapOrderAddresses, find_swap_order_address
+from sdk_commons.config import OfferTokenDetails
 
 from .bid_details import BidDetails
 from .friktion_anchor.accounts import SwapOrder
@@ -116,7 +117,7 @@ class SwapContract:
         acct_info = self.get_account_info(mint, wallet)
         return acct_info.delegated_amount, acct_info.amount
 
-    async def get_offered_token_details(self, user: PublicKey, order_id: int):
+    async def get_offered_token_details(self, user: PublicKey, order_id: int) -> OfferTokenDetails:
         swap_order = await self.get_swap_order(user, order_id)
         options_contract = await self.get_options_contract_for_key(swap_order.options_contract)
         ul_factor = await self._get_token_norm_factor(options_contract.underlying_mint)
@@ -130,14 +131,16 @@ class SwapContract:
             * options_contract.underlying_amount
             / options_contract.quote_amount
         )
+
+        # TODO: enforce specific types on OfferTokenDetails
         return {
-            'underlyingAsset': options_contract.underlying_mint,
+            'underlyingAsset': str(options_contract.underlying_mint),
             # options expiration is in seconds since epoch
-            'expiryTimestamp': options_contract.expiry_ts,
+            'expiryTimestamp': str(options_contract.expiry_ts),
             'isPut': not options_contract.is_call,
-            'strikeAsset': options_contract.quote_mint,
-            'strikePrice': strike_price,
-            'collateralAsset': options_contract.underlying_mint,
+            'strikeAsset': str(options_contract.quote_mint),
+            'strikePrice': str(strike_price),
+            'collateralAsset': str(options_contract.underlying_mint),
         }
 
     async def _get_token_norm_factor(self, mint: PublicKey) -> int:

--- a/friktion/friktion/swap.py
+++ b/friktion/friktion/swap.py
@@ -124,10 +124,6 @@ class SwapContract:
         ul_factor = await self._get_token_norm_factor(options_contract.underlying_mint)
         quote_factor = await self._get_token_norm_factor(options_contract.quote_mint)
 
-        # TODO: introduce rounding to prevent too long values?
-        # for example when we get 333333333.3333333 and we
-        # convert to decimal we obtain:
-        # 333333333.333333313465118408203125 that is too long!
         strike_price = (
             (ul_factor / quote_factor)
             * options_contract.quote_amount

--- a/friktion/friktion/swap.py
+++ b/friktion/friktion/swap.py
@@ -4,6 +4,7 @@
 """ Module to call Swap contract """
 import asyncio
 import time
+from decimal import Decimal
 from enum import Enum
 from typing import Optional, Tuple
 
@@ -132,14 +133,13 @@ class SwapContract:
             / options_contract.quote_amount
         )
 
-        # TODO: enforce specific types on OfferTokenDetails
         return {
             'underlyingAsset': str(options_contract.underlying_mint),
             # options expiration is in seconds since epoch
             'expiryTimestamp': options_contract.expiry_ts,
             'isPut': not options_contract.is_call,
             'strikeAsset': str(options_contract.quote_mint),
-            'strikePrice': str(strike_price),
+            'strikePrice': Decimal(strike_price),
             'collateralAsset': str(options_contract.underlying_mint),
         }
 

--- a/friktion/friktion/swap.py
+++ b/friktion/friktion/swap.py
@@ -4,7 +4,6 @@
 """ Module to call Swap contract """
 import asyncio
 import time
-from decimal import Decimal
 from enum import Enum
 from typing import Optional, Tuple
 
@@ -123,6 +122,11 @@ class SwapContract:
         options_contract = await self.get_options_contract_for_key(swap_order.options_contract)
         ul_factor = await self._get_token_norm_factor(options_contract.underlying_mint)
         quote_factor = await self._get_token_norm_factor(options_contract.quote_mint)
+
+        # TODO: introduce a round to prevent to long values?
+        # for example when we get 333333333.3333333 and we
+        # convert to decimal we obtain:
+        # 333333333.333333313465118408203125 that is
         strike_price = (
             (ul_factor / quote_factor)
             * options_contract.quote_amount
@@ -139,7 +143,7 @@ class SwapContract:
             'expiryTimestamp': options_contract.expiry_ts,
             'isPut': not options_contract.is_call,
             'strikeAsset': str(options_contract.quote_mint),
-            'strikePrice': Decimal(strike_price),
+            'strikePrice': strike_price,
             'collateralAsset': str(options_contract.underlying_mint),
         }
 

--- a/friktion/friktion/swap.py
+++ b/friktion/friktion/swap.py
@@ -4,6 +4,7 @@
 """ Module to call Swap contract """
 import asyncio
 import time
+from decimal import Decimal
 from enum import Enum
 from typing import Optional, Tuple
 
@@ -123,7 +124,7 @@ class SwapContract:
         ul_factor = await self._get_token_norm_factor(options_contract.underlying_mint)
         quote_factor = await self._get_token_norm_factor(options_contract.quote_mint)
 
-        # TODO: introduce rounding to prevent to long values?
+        # TODO: introduce rounding to prevent too long values?
         # for example when we get 333333333.3333333 and we
         # convert to decimal we obtain:
         # 333333333.333333313465118408203125 that is too long!
@@ -143,7 +144,9 @@ class SwapContract:
             'expiryTimestamp': options_contract.expiry_ts,
             'isPut': not options_contract.is_call,
             'strikeAsset': str(options_contract.quote_mint),
-            'strikePrice': strike_price,
+            # float -> str -> Decimal to prevent changing
+            # the precision due to floating point arithmetic
+            'strikePrice': Decimal(str(strike_price)),
             'collateralAsset': str(options_contract.underlying_mint),
         }
 

--- a/friktion/friktion/swap.py
+++ b/friktion/friktion/swap.py
@@ -136,7 +136,7 @@ class SwapContract:
         return {
             'underlyingAsset': str(options_contract.underlying_mint),
             # options expiration is in seconds since epoch
-            'expiryTimestamp': str(options_contract.expiry_ts),
+            'expiryTimestamp': options_contract.expiry_ts,
             'isPut': not options_contract.is_call,
             'strikeAsset': str(options_contract.quote_mint),
             'strikePrice': str(strike_price),

--- a/friktion/friktion/swap.py
+++ b/friktion/friktion/swap.py
@@ -123,10 +123,10 @@ class SwapContract:
         ul_factor = await self._get_token_norm_factor(options_contract.underlying_mint)
         quote_factor = await self._get_token_norm_factor(options_contract.quote_mint)
 
-        # TODO: introduce a round to prevent to long values?
+        # TODO: introduce rounding to prevent to long values?
         # for example when we get 333333333.3333333 and we
         # convert to decimal we obtain:
-        # 333333333.333333313465118408203125 that is
+        # 333333333.333333313465118408203125 that is too long!
         strike_price = (
             (ul_factor / quote_factor)
             * options_contract.quote_amount

--- a/friktion/pyproject.toml
+++ b/friktion/pyproject.toml
@@ -10,6 +10,8 @@ solana = "0.25.0"
 anchorpy = "0.9.4"
 requests = "^2.28.1"
 solders = "^0.2.0"
+asgiref = "^3.5.2"
+types-requests = "^2.28.0"
 
 [tool.poetry.dev-dependencies]
 pytest="^6.2.5"

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -24,7 +24,8 @@ class OfferTokenDetails(TypedDict):
     strikeAsset: str
     # TODO: expected to be Decimal
     strikePrice: str
-    expiryTimestamp: str
+    # expiration in seconds since epoch
+    expiryTimestamp: int
     isPut: bool
 
 

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -1,4 +1,5 @@
 import abc
+from decimal import Decimal
 from typing import Any, TypedDict
 
 from sdk_commons.chains import Chains
@@ -10,10 +11,8 @@ class OfferDetails(TypedDict):
     oToken: str
     biddingToken: str
     minPrice: str
-    # TODO: expected to be Decimal
-    minBidSize: str
-    # TODO: expected to be Decimal
-    totalSize: str
+    minBidSize: Decimal
+    totalSize: Decimal
     availableSize: str
 
 
@@ -22,8 +21,7 @@ class OfferTokenDetails(TypedDict):
     collateralAsset: str
     underlyingAsset: str
     strikeAsset: str
-    # TODO: expected to be Decimal
-    strikePrice: str
+    strikePrice: Decimal
     # expiration in seconds since epoch
     expiryTimestamp: int
     isPut: bool

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -75,6 +75,7 @@ class SDKConfig(abc.ABC):
     @abc.abstractmethod
     def create_offer(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
@@ -86,7 +87,6 @@ class SDKConfig(abc.ABC):
         offer_amount: int,
         public_key: str,
         private_key: str,
-        *args: Any,
         **kwargs: Any,
     ) -> str:
         """
@@ -97,12 +97,12 @@ class SDKConfig(abc.ABC):
     @abc.abstractmethod
     def get_otoken_details(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         offer_id: int,
         seller: str,
-        *args: Any,
         **kwargs: Any,
     ) -> OfferTokenDetails:
         """
@@ -112,12 +112,12 @@ class SDKConfig(abc.ABC):
     @abc.abstractmethod
     def get_offer_details(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         offer_id: int,
         seller: str,
-        *args: Any,
         **kwargs: Any,
     ) -> OfferDetails:
         """Return details for a given offer"""
@@ -125,6 +125,7 @@ class SDKConfig(abc.ABC):
     @abc.abstractmethod
     def validate_bid(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
@@ -135,7 +136,6 @@ class SDKConfig(abc.ABC):
         buy_amount: int,
         referrer: str,
         signature: str,
-        *args: Any,
         **kwargs: Any,
     ) -> BidValidation:
         """Validate the signing bid"""
@@ -143,12 +143,12 @@ class SDKConfig(abc.ABC):
     @abc.abstractmethod
     def verify_allowance(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         public_key: str,
         token_address: str,
-        *args: Any,
         **kwargs: Any,
     ) -> bool:
         """

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -25,7 +25,7 @@ class OfferTokenDetails(TypedDict):
     # TODO: expected to be Decimal
     strikePrice: str
     expiryTimestamp: str
-    isPut: str
+    isPut: bool
 
 
 class BidValidation(TypedDict, total=False):

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -92,7 +92,14 @@ class SDKConfig(abc.ABC):
     # TODO: rename into get_offered_token_details
     @abc.abstractmethod
     def get_otoken_details(
-        self, contract_address: str, chain_id: int, rpc_uri: str, *args: Any, **kwargs: Any
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        offer_id: int,
+        seller: str,
+        *args: Any,
+        **kwargs: Any,
     ) -> OfferTokenDetails:
         """
         Return details about the offer token
@@ -105,6 +112,7 @@ class SDKConfig(abc.ABC):
         chain_id: int,
         rpc_uri: str,
         offer_id: int,
+        seller: str,
         *args: Any,
         **kwargs: Any,
     ) -> OfferDetails:

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -21,7 +21,12 @@ class OfferTokenDetails(TypedDict):
     collateralAsset: str
     underlyingAsset: str
     strikeAsset: str
-    strikePrice: Decimal
+    # TODO: should be a Decimal?
+    # strike_price in friktion.swap.get_offered_token_details
+    # is computed as 333333333.3333333, if converted to decimal we get
+    # 333333333.333333313465118408203125 that is unexpectedly long
+    # Introduce a rounding?
+    strikePrice: float
     # expiration in seconds since epoch
     expiryTimestamp: int
     isPut: bool

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -129,6 +129,7 @@ class SDKConfig(abc.ABC):
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
+        seller: str,
         swap_id: int,
         nonce: int,
         signer_wallet: str,

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -21,12 +21,7 @@ class OfferTokenDetails(TypedDict):
     collateralAsset: str
     underlyingAsset: str
     strikeAsset: str
-    # TODO: should be a Decimal?
-    # strike_price in friktion.swap.get_offered_token_details
-    # is computed as 333333333.3333333, if converted to decimal we get
-    # 333333333.333333313465118408203125 that is unexpectedly long
-    # Introduce a rounding?
-    strikePrice: float
+    strikePrice: Decimal
     # expiration in seconds since epoch
     expiryTimestamp: int
     isPut: bool

--- a/template/template/otoken.py
+++ b/template/template/otoken.py
@@ -1,6 +1,8 @@
 # ---------------------------------------------------------------------------
 """ Module to call oToken contract """
 # ---------------------------------------------------------------------------
+from decimal import Decimal
+
 from sdk_commons.config import OfferTokenDetails
 from template.definitions import ContractConfig
 
@@ -30,7 +32,7 @@ class oTokenContract:
             "collateralAsset": "...",
             "underlyingAsset": "...",
             "strikeAsset": "...",
-            "strikePrice": 0.0,
+            "strikePrice": Decimal(0.0),
             "expiryTimestamp": 0,
             "isPut": True,
         }

--- a/template/template/otoken.py
+++ b/template/template/otoken.py
@@ -1,8 +1,6 @@
 # ---------------------------------------------------------------------------
 """ Module to call oToken contract """
 # ---------------------------------------------------------------------------
-from decimal import Decimal
-
 from sdk_commons.config import OfferTokenDetails
 from template.definitions import ContractConfig
 
@@ -32,7 +30,7 @@ class oTokenContract:
             "collateralAsset": "...",
             "underlyingAsset": "...",
             "strikeAsset": "...",
-            "strikePrice": Decimal(0.0),
+            "strikePrice": 0.0,
             "expiryTimestamp": 0,
             "isPut": True,
         }

--- a/template/template/otoken.py
+++ b/template/template/otoken.py
@@ -1,6 +1,7 @@
 # ---------------------------------------------------------------------------
 """ Module to call oToken contract """
 # ---------------------------------------------------------------------------
+from decimal import Decimal
 
 from sdk_commons.config import OfferTokenDetails
 from template.definitions import ContractConfig
@@ -31,7 +32,7 @@ class oTokenContract:
             "collateralAsset": "...",
             "underlyingAsset": "...",
             "strikeAsset": "...",
-            "strikePrice": "...",
+            "strikePrice": Decimal(0.0),
             "expiryTimestamp": 0,
             "isPut": True,
         }

--- a/template/template/otoken.py
+++ b/template/template/otoken.py
@@ -33,5 +33,5 @@ class oTokenContract:
             "strikeAsset": "...",
             "strikePrice": "...",
             "expiryTimestamp": "...",
-            "isPut": "...",
+            "isPut": True,
         }

--- a/template/template/otoken.py
+++ b/template/template/otoken.py
@@ -32,6 +32,6 @@ class oTokenContract:
             "underlyingAsset": "...",
             "strikeAsset": "...",
             "strikePrice": "...",
-            "expiryTimestamp": "...",
+            "expiryTimestamp": 0,
             "isPut": True,
         }

--- a/template/template/swap.py
+++ b/template/template/swap.py
@@ -1,4 +1,6 @@
 """ Module to call Swap contract """
+from decimal import Decimal
+
 from sdk_commons.config import BidValidation, OfferDetails
 from template.definitions import ContractConfig, Offer, SignedBid
 from template.wallet import Wallet
@@ -37,8 +39,8 @@ class SwapContract:
             'oToken': "...",
             'biddingToken': "...",
             'minPrice': "...",
-            'minBidSize': "...",
-            'totalSize': "...",
+            'minBidSize': Decimal(0.0),
+            'totalSize': Decimal(0.0),
             'availableSize': "...",
         }
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,14 +1,23 @@
+from enum import Enum
 from importlib import import_module
 from inspect import Parameter, signature
 
 from sdk_commons.config import SDKConfig
 
-TEMPLATE = 'template'
-RIBBON = 'ribbon'
-OPYN = 'opyn'
-FRIKTION = 'friktion'
-# TODO: add FRIKTION
-VENUES = [TEMPLATE, RIBBON, OPYN]
+
+class VenuePackages(Enum):
+    TEMPLATE = 'template'
+    RIBBON = 'ribbon'
+    FRIKTION = 'friktion'
+    OPYN = 'opyn'
+
+
+VENUES = [
+    VenuePackages.TEMPLATE.value,
+    VenuePackages.RIBBON.value,
+    VenuePackages.FRIKTION.value,
+    VenuePackages.OPYN.value,
+]
 
 
 class TestsBase:
@@ -99,12 +108,13 @@ class TestsBase:
 
         # Verify if the arguments of the method signature
         # corresponds to the reference signature
-        for method_name, method_def in method_signature.items():
+        for param_name, method_def in method_signature.items():
             # args and kwargs are already explicitly checked, skipping
-            if method_name == "args" or method_name == "kwargs":
+            if param_name == "args" or param_name == "kwargs":
                 continue
             # Unknown parameters (i.e. parameters not in the reference)
             # are refused, except if they have a default value
+            method_path = f"{method.__module__}.{method.__name__}"
             assert (
-                method_name in expected_params or method_def.default is not Parameter.empty
-            ), f"{method} requires an unknown parameter {method_name}"
+                param_name in expected_params or method_def.default is not Parameter.empty
+            ), f"{method_path} is asking for an unknown parameter {param_name}"


### PR DESCRIPTION
Now that the SDK interface is merged we can start working on extending it to Friktion

To ease the work I prepared a base setup: I do not expect that it is working but can be a starting point to avoid you starting from scratch

Please note that here I extended get_otoken_details with offer_id and seller parameters and get_offer_details with seller parameter by adding it to both the abstract config and to the Friktion config. Other venues will ignore the new parameters (consumed via kwargs).
Our side, just updated the drafted PR to send the new parameters
