### PR TITLE
Ribbon minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sdks
 
 Repository with public SDKs of Blockchain venues
-currently integrating with "Paradigm Co.".
+currently integrating with Paradigm Co.
 
 ## Development
 
@@ -9,9 +9,9 @@ To contribute to this package you may set up a dedicated container:
 
 ```bash
 $ git clone git@github.com:tradeparadigm/sdks.git
-$ cd ribbon
+$ cd your-venue
 $ pwd
-[...]/sdks/ribbon
+[...]/sdks/your-venue
 
 # open a container with python
 $ docker run -it --rm \
@@ -21,9 +21,9 @@ $ docker run -it --rm \
     bash
 
 # install the library in development mode
-pip3 install -e /tmp/code
+pip3 install --editable /tmp/code
 
-# run code that accesses the ribbon sdk, e.g.
+# run code that accesses the SDK, e.g.
 python3 test.py
 
 # optional: add and use ipython/jypiter

--- a/ribbon/ribbon/utils.py
+++ b/ribbon/ribbon/utils.py
@@ -63,10 +63,7 @@ def hex_concat(items: list) -> str:
     Returns:
         hex (str): Concatenated hex
     """
-    result = '0x'
-    for i in items:
-        result += i[2:]
-    return result
+    return '0x' + ''.join([i[2:] for i in items])
 
 
 def is_hex_string(value: str, length: int = None) -> bool:


### PR DESCRIPTION
Some minor things that I propose to change:

- Rename type arguments into data_type
(type is a built-in function, should not be used as a parameter)

- Change how boundsLower is calculated
(equivalent expression but I find it more clear)

- Remove .keys() for dict iterations and assertions
(in operator already search between keys and for operator loop over keys
by default, so no need to create a .keys iterator

- Replace list(dict.keys()) + sort with sorted(dict.keys())
(equivalent but shorter and faster)

- Remove a double for loop (the 1st used to initialize some dictionaries)

- Remove a print(length) that was probably some old debug code

- Replace string concatenation in a loop with the join operator

P.S. I would like to ask a review to Ken, but I can't find his username on github