### PR TITLE
[Friktion] Ajust signature msg to match Phantom

### DIFF
--- a/friktion/friktion/bid_details.py
+++ b/friktion/friktion/bid_details.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -17,15 +18,17 @@ class BidDetails:
     def as_msg(self):
         give_amount = self.bid_size
         receive_amount = self.bid_price * self.bid_size
-        byte_rep = b"".join(
-            [
-                bytes([self.order_id]),
-                bytes(str(self.signer_wallet), 'utf-8'),
-                bytes(str(self.referrer), 'utf-8'),
-                bytes([give_amount, receive_amount]),
-            ]
-        )
-        return byte_rep
+        payload = [
+            [self.order_id],
+            str(self.signer_wallet),
+            str(self.referrer),
+            [give_amount, receive_amount],
+        ]
+
+        # set separators to remove whitespaces
+        dumped_payload = json.dumps(payload, separators=(',', ':'))
+
+        return bytes(dumped_payload, 'utf-8')
 
     def as_signed_msg(self, wallet: Wallet) -> Tuple[bytes, Signature]:
         msg_bytes = self.as_msg()


### PR DESCRIPTION
Stringfy the payload to avoid inconsistencies with the signed
msg by Phantom.

Also fix the bytes conversion error for buy and sell amount.

![Screen Shot 2022-08-02 at 17 40 01](https://user-images.githubusercontent.com/4041238/182470828-39ecdf29-4b2b-46bc-acfc-1d2e1fe5d0e8.png)
