### PR TITLE
Adjust sdk interface for the new signature format

### DIFF
--- a/opyn/opyn/config.py
+++ b/opyn/opyn/config.py
@@ -4,7 +4,7 @@ from opyn.settlement import SettlementContract
 from opyn.wallet import Wallet
 from sdk_commons.chains import Chains
 from sdk_commons.config import SDKConfig
-from sdk_commons.helpers import break_evm_signature_into_components
+from sdk_commons.helpers import get_evm_signature_components
 
 
 class AuthorizationPages:
@@ -81,7 +81,7 @@ class OpynSDKConfig(SDKConfig):
         **kwargs,
     ) -> str:
         """Validate the signing bid"""
-        r, s, v = break_evm_signature_into_components(signature)
+        r, s, v = get_evm_signature_components(signature)
 
         config = ContractConfig(
             address=contract_address,

--- a/opyn/opyn/config.py
+++ b/opyn/opyn/config.py
@@ -4,6 +4,7 @@ from opyn.settlement import SettlementContract
 from opyn.wallet import Wallet
 from sdk_commons.chains import Chains
 from sdk_commons.config import SDKConfig
+from sdk_commons.helpers import break_evm_signature_into_components
 
 
 class AuthorizationPages:
@@ -76,12 +77,11 @@ class OpynSDKConfig(SDKConfig):
         sell_amount: int,
         buy_amount: int,
         referrer: str,
-        v: int,
-        r: str,
-        s: str,
+        signature: str,
         **kwargs,
     ) -> str:
         """Validate the signing bid"""
+        r, s, v = break_evm_signature_into_components(signature)
 
         config = ContractConfig(address=contract_address, chain_id=chain_id, rpc_uri=rpc_uri)
         swap_contract = SettlementContract(config)

--- a/opyn/opyn/config.py
+++ b/opyn/opyn/config.py
@@ -83,7 +83,11 @@ class OpynSDKConfig(SDKConfig):
         """Validate the signing bid"""
         r, s, v = break_evm_signature_into_components(signature)
 
-        config = ContractConfig(address=contract_address, chain_id=chain_id, rpc_uri=rpc_uri)
+        config = ContractConfig(
+            address=contract_address,
+            chain_id=Chains(chain_id),
+            rpc_uri=rpc_uri,
+        )
         swap_contract = SettlementContract(config)
 
         # Expected to fail: BidData currently has a different signature

--- a/ribbon/ribbon/config.py
+++ b/ribbon/ribbon/config.py
@@ -4,6 +4,7 @@ from ribbon.swap import SwapContract
 from ribbon.wallet import Wallet
 from sdk_commons.chains import Chains
 from sdk_commons.config import SDKConfig
+from sdk_commons.helpers import break_evm_signature_into_components
 
 
 class AuthorizationPages:
@@ -78,12 +79,11 @@ class RibbonSDKConfig(SDKConfig):
         sell_amount: int,
         buy_amount: int,
         referrer: str,
-        v: int,
-        r: str,
-        s: str,
+        signature: str,
         **kwargs,
     ) -> str:
         """Validate the signing bid"""
+        r, s, v = break_evm_signature_into_components(signature)
 
         config = ContractConfig(address=contract_address, chain_id=chain_id, rpc_uri=rpc_uri)
         swap_contract = SwapContract(config)

--- a/ribbon/ribbon/config.py
+++ b/ribbon/ribbon/config.py
@@ -4,7 +4,7 @@ from ribbon.swap import SwapContract
 from ribbon.wallet import Wallet
 from sdk_commons.chains import Chains
 from sdk_commons.config import SDKConfig
-from sdk_commons.helpers import break_evm_signature_into_components
+from sdk_commons.helpers import get_evm_signature_components
 
 
 class AuthorizationPages:
@@ -83,7 +83,7 @@ class RibbonSDKConfig(SDKConfig):
         **kwargs,
     ) -> str:
         """Validate the signing bid"""
-        r, s, v = break_evm_signature_into_components(signature)
+        r, s, v = get_evm_signature_components(signature)
 
         config = ContractConfig(
             address=contract_address,

--- a/ribbon/ribbon/config.py
+++ b/ribbon/ribbon/config.py
@@ -85,7 +85,11 @@ class RibbonSDKConfig(SDKConfig):
         """Validate the signing bid"""
         r, s, v = break_evm_signature_into_components(signature)
 
-        config = ContractConfig(address=contract_address, chain_id=chain_id, rpc_uri=rpc_uri)
+        config = ContractConfig(
+            address=contract_address,
+            chain_id=Chains(chain_id),
+            rpc_uri=rpc_uri,
+        )
         swap_contract = SwapContract(config)
 
         signed_bid = SignedBid(

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -80,9 +80,7 @@ class SDKConfig(abc.ABC):
         sell_amount: int,
         buy_amount: int,
         referrer: str,
-        v: int,
-        r: str,
-        s: str,
+        signature: str,
         **kwargs,
     ) -> str:
         """Validate the signing bid"""

--- a/sdk_commons/sdk_commons/helpers.py
+++ b/sdk_commons/sdk_commons/helpers.py
@@ -1,0 +1,12 @@
+EVM_SIGNATURE_LEN = 130
+
+
+def break_evm_signature_into_components(signature: str) -> tuple[str, str, int]:
+    if len(signature) != EVM_SIGNATURE_LEN:
+        raise ValueError(f'Invalid signature. Expected {EVM_SIGNATURE_LEN} character-long string')
+
+    r = f'0x{signature[:64]}'
+    s = f'0x{signature[64:128]}'
+    v = int(signature[128:130], 16)
+
+    return r, s, v

--- a/sdk_commons/sdk_commons/helpers.py
+++ b/sdk_commons/sdk_commons/helpers.py
@@ -1,7 +1,7 @@
 EVM_SIGNATURE_LEN = 130
 
 
-def break_evm_signature_into_components(signature: str) -> tuple[str, str, int]:
+def get_evm_signature_components(signature: str) -> tuple[str, str, int]:
     if len(signature) != EVM_SIGNATURE_LEN:
         raise ValueError(f'Invalid signature. Expected {EVM_SIGNATURE_LEN} character-long string')
 

--- a/template/template/config.py
+++ b/template/template/config.py
@@ -80,7 +80,11 @@ class TemplateSDKConfig(SDKConfig):
         """Validate the signing bid"""
         r, s, v = break_evm_signature_into_components(signature)
 
-        config = ContractConfig(address=contract_address, chain_id=chain_id, rpc_uri=rpc_uri)
+        config = ContractConfig(
+            address=contract_address,
+            chain_id=Chains(chain_id),
+            rpc_uri=rpc_uri,
+        )
         swap_contract = SwapContract(config)
 
         signed_bid = SignedBid(

--- a/template/template/config.py
+++ b/template/template/config.py
@@ -1,6 +1,6 @@
 from sdk_commons.chains import Chains
 from sdk_commons.config import SDKConfig
-from sdk_commons.helpers import break_evm_signature_into_components
+from sdk_commons.helpers import get_evm_signature_components
 from template.definitions import ContractConfig, Offer, SignedBid
 from template.otoken import oTokenContract
 from template.swap import SwapContract
@@ -78,7 +78,7 @@ class TemplateSDKConfig(SDKConfig):
         **kwargs,
     ) -> str:
         """Validate the signing bid"""
-        r, s, v = break_evm_signature_into_components(signature)
+        r, s, v = get_evm_signature_components(signature)
 
         config = ContractConfig(
             address=contract_address,

--- a/template/template/config.py
+++ b/template/template/config.py
@@ -1,5 +1,6 @@
 from sdk_commons.chains import Chains
 from sdk_commons.config import SDKConfig
+from sdk_commons.helpers import break_evm_signature_into_components
 from template.definitions import ContractConfig, Offer, SignedBid
 from template.otoken import oTokenContract
 from template.swap import SwapContract
@@ -73,12 +74,11 @@ class TemplateSDKConfig(SDKConfig):
         sell_amount: int,
         buy_amount: int,
         referrer: str,
-        v: int,
-        r: str,
-        s: str,
+        signature: str,
         **kwargs,
     ) -> str:
         """Validate the signing bid"""
+        r, s, v = break_evm_signature_into_components(signature)
 
         config = ContractConfig(address=contract_address, chain_id=chain_id, rpc_uri=rpc_uri)
         swap_contract = SwapContract(config)


### PR DESCRIPTION
Receives a single string instead of the components.
This change was made to accommodate Solana signatures.

Note: These interfaces are not in use yet

![Screen Shot 2022-08-19 at 10 52 09](https://user-images.githubusercontent.com/4041238/185634217-f9d499d3-f10e-4378-8a5d-efdb6b8e2511.png)
