### PR TITLE
Added *args to all interface methods

### DIFF
--- a/opyn/opyn/config.py
+++ b/opyn/opyn/config.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from opyn.definitions import BidData, ContractConfig, Offer
 from opyn.otoken import oTokenContract
 from opyn.settlement import SettlementContract
@@ -32,7 +34,8 @@ class OpynSDKConfig(SDKConfig):
         offer_amount: int,
         public_key: str,
         private_key: str,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> str:
         """Create an offer"""
 
@@ -54,7 +57,12 @@ class OpynSDKConfig(SDKConfig):
         return swap_contract.create_offer(new_offer, wallet)
 
     def get_otoken_details(
-        self, contract_address: str, chain_id: int, rpc_uri: str, **kwargs
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        *args: Any,
+        **kwargs: Any,
     ) -> OfferTokenDetails:
         """Return details about the offer token"""
 
@@ -65,7 +73,13 @@ class OpynSDKConfig(SDKConfig):
         return otoken_contract.get_otoken_details()
 
     def get_offer_details(
-        self, contract_address: str, chain_id: int, rpc_uri: str, offer_id: int, **kwargs
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        offer_id: int,
+        *args: Any,
+        **kwargs: Any,
     ) -> OfferDetails:
         """Return details for a given offer"""
 
@@ -87,7 +101,8 @@ class OpynSDKConfig(SDKConfig):
         buy_amount: int,
         referrer: str,
         signature: str,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> BidValidation:
         """Validate the signing bid"""
         r, s, v = get_evm_signature_components(signature)
@@ -126,7 +141,8 @@ class OpynSDKConfig(SDKConfig):
         rpc_uri: str,
         public_key: str,
         token_address: str,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> bool:
         """
         Verify if the contract is allowed to access

--- a/ribbon/ribbon/config.py
+++ b/ribbon/ribbon/config.py
@@ -36,6 +36,7 @@ class RibbonSDKConfig(SDKConfig):
         offer_amount: int,
         public_key: str,
         private_key: str,
+        *args: Any,
         **kwargs: Any,
     ) -> str:
         """Create an offer"""
@@ -58,7 +59,7 @@ class RibbonSDKConfig(SDKConfig):
         return swap_contract.create_offer(new_offer, wallet)
 
     def get_otoken_details(
-        self, contract_address: str, chain_id: int, rpc_uri: str, **kwargs
+        self, contract_address: str, chain_id: int, rpc_uri: str, *args: Any, **kwargs: Any
     ) -> OfferTokenDetails:
         """Return details about the offer token"""
 
@@ -70,7 +71,13 @@ class RibbonSDKConfig(SDKConfig):
         return otoken_contract.get_otoken_details()
 
     def get_offer_details(
-        self, contract_address: str, chain_id: int, rpc_uri: str, offer_id: int, **kwargs
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        offer_id: int,
+        *args: Any,
+        **kwargs: Any,
     ) -> OfferDetails:
         """Return details for a given offer"""
 
@@ -93,7 +100,8 @@ class RibbonSDKConfig(SDKConfig):
         buy_amount: int,
         referrer: str,
         signature: str,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> BidValidation:
         """Validate the signing bid"""
         r, s, v = get_evm_signature_components(signature)
@@ -126,7 +134,8 @@ class RibbonSDKConfig(SDKConfig):
         rpc_uri: str,
         public_key: str,
         token_address: str,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> bool:
         """
         Verify if the contract is allowed to access

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -82,6 +82,7 @@ class SDKConfig(abc.ABC):
         offer_amount: int,
         public_key: str,
         private_key: str,
+        *args: Any,
         **kwargs: Any,
     ) -> str:
         """
@@ -91,7 +92,7 @@ class SDKConfig(abc.ABC):
     # TODO: rename into get_offered_token_details
     @abc.abstractmethod
     def get_otoken_details(
-        self, contract_address: str, chain_id: int, rpc_uri: str, **kwargs: Any
+        self, contract_address: str, chain_id: int, rpc_uri: str, *args: Any, **kwargs: Any
     ) -> OfferTokenDetails:
         """
         Return details about the offer token
@@ -99,7 +100,13 @@ class SDKConfig(abc.ABC):
 
     @abc.abstractmethod
     def get_offer_details(
-        self, contract_address: str, chain_id: int, rpc_uri: str, offer_id: int, **kwargs: Any
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        offer_id: int,
+        *args: Any,
+        **kwargs: Any,
     ) -> OfferDetails:
         """Return details for a given offer"""
 
@@ -116,6 +123,7 @@ class SDKConfig(abc.ABC):
         buy_amount: int,
         referrer: str,
         signature: str,
+        *args: Any,
         **kwargs: Any,
     ) -> BidValidation:
         """Validate the signing bid"""
@@ -128,6 +136,7 @@ class SDKConfig(abc.ABC):
         rpc_uri: str,
         public_key: str,
         token_address: str,
+        *args: Any,
         **kwargs: Any,
     ) -> bool:
         """

--- a/template/template/config.py
+++ b/template/template/config.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from sdk_commons.chains import Chains
 from sdk_commons.config import BidValidation, OfferDetails, OfferTokenDetails, SDKConfig
 from sdk_commons.helpers import get_evm_signature_components
@@ -29,7 +31,8 @@ class TemplateSDKConfig(SDKConfig):
         offer_amount: int,
         public_key: str,
         private_key: str,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> str:
         """Create an offer"""
 
@@ -51,7 +54,12 @@ class TemplateSDKConfig(SDKConfig):
         return swap_contract.create_offer(new_offer, wallet)
 
     def get_otoken_details(
-        self, contract_address: str, chain_id: int, rpc_uri: str, **kwargs
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        *args: Any,
+        **kwargs: Any,
     ) -> OfferTokenDetails:
         """Return details about the offer token"""
 
@@ -63,7 +71,13 @@ class TemplateSDKConfig(SDKConfig):
         return otoken_contract.get_otoken_details()
 
     def get_offer_details(
-        self, contract_address: str, chain_id: int, rpc_uri: str, offer_id: int, **kwargs
+        self,
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        offer_id: int,
+        *args: Any,
+        **kwargs: Any,
     ) -> OfferDetails:
         """Return details for a given offer"""
 
@@ -86,7 +100,8 @@ class TemplateSDKConfig(SDKConfig):
         buy_amount: int,
         referrer: str,
         signature: str,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> BidValidation:
         """Validate the signing bid"""
         r, s, v = get_evm_signature_components(signature)
@@ -119,7 +134,8 @@ class TemplateSDKConfig(SDKConfig):
         rpc_uri: str,
         public_key: str,
         token_address: str,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> bool:
         """
         Verify if the contract is allowed to access

--- a/tests/base.py
+++ b/tests/base.py
@@ -73,10 +73,20 @@ class TestsBase:
         method_signature = signature(method).parameters
         reference_signature = signature(reference).parameters
 
-        # All concrete implementes are expencted to accept **kwargs
+        # All concrete implementations are expected to accept *args
+        assert (
+            "args" in method_signature
+        ), f"{method.__module__}.{method.__name__} is not accepting *args parameter"
+
+        # Verify that args is exactly *args
+        assert (
+            method_signature["args"].kind == Parameter.VAR_POSITIONAL
+        ), "wrong args argument, expected *args"
+
+        # All concrete implementations are expected to accept **kwargs
         assert (
             "kwargs" in method_signature
-        ), f"{method.__module__}.{method.__name__} is not accepting kwargs parameter"
+        ), f"{method.__module__}.{method.__name__} is not accepting **kwargs parameter"
 
         # Verify that kwargs is exactly **kwargs
         assert (


### PR DESCRIPTION
In a previous PR we decided to simplify the interface methods by only including **kwargs, because functionally enough to support required use cases. In particular we would like to be able to expand the interface signature with optional arguments and letting venues to ignore non required parameters by consuming them via **kwargs
```
abstract method = def xx(self, a, b, c, **kwargs):

concrete method = def xx(self, a, b, **kwargs):
```

We first introduced this functionality on the [Friktion SDK](https://github.com/tradeparadigm/sdks/pull/46) to add `seller` argument to both `get_otoken_details` and `get_offer_details`

When we introduced mypy checks and rebased the Friktion SDK PR, mypy started blaming us about invalid signatures

```
error: Signature of "get_offer_details" incompatible with supertype "SDKConfig"
note:      Superclass:
note:          def get_offer_details(self, contract_address: str, chain_id: int, rpc_uri: str, offer_id: int, seller: str, **kwargs: Any) -> OfferDetails
note:      Subclass:
note:          def get_offer_details(self, contract_address: str, chain_id: int, rpc_uri: str, offer_id: int, **kwargs: Any) -> OfferDetails
```

This somehow violates Liskov substitutability and therefore is unaccepted by mypy. Introducing *args in addition to **kwargs    is enough to fix the issue

Invalid override:
```
get_offer_details(self, other-arguments, seller: str, **kwargs: Any) 
get_offer_details(self, other-arguments, **kwargs: Any)
```

valid override:

```
get_offer_details(self, other-arguments, seller: str, *args: Any, **kwargs: Any) 
get_offer_details(self, other-arguments, *args: Any, **kwargs: Any)
```
