### PR TITLE
Fix Domain.version type to match the encoded types

### DIFF
--- a/ribbon/ribbon/config.py
+++ b/ribbon/ribbon/config.py
@@ -107,7 +107,7 @@ class RibbonSDKConfig(SDKConfig):
 
         domain = Domain(
             name="RIBBON SWAP",
-            version=1,
+            version="1",
             chainId=chain_id,
             verifyingContract=contract_address,
         )

--- a/ribbon/ribbon/definitions.py
+++ b/ribbon/ribbon/definitions.py
@@ -35,7 +35,7 @@ class Domain:
     name: str
     chainId: int
     verifyingContract: str
-    version: int
+    version: str
     salt: Optional[str] = None
 
 

--- a/template/template/definitions.py
+++ b/template/template/definitions.py
@@ -22,7 +22,7 @@ class Domain:
     """
 
     name: str
-    version: int
+    version: str
     chainId: int
     verifyingContract: str
 


### PR DESCRIPTION
Domain.version was annotated as an int but the correct type
sent with DOMAIN_FIELD_TYPES is string