### PR TITLE
Replaced *args with * on interface methods

### DIFF
--- a/friktion/friktion/config.py
+++ b/friktion/friktion/config.py
@@ -39,6 +39,7 @@ class FriktionSDKConfig(SDKConfig):
 
     def create_offer(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
@@ -49,7 +50,6 @@ class FriktionSDKConfig(SDKConfig):
         offer_amount: int,
         public_key: str,
         private_key: str,
-        *args: Any,
         **kwargs: Any,
     ) -> str:
         """Create an offer"""
@@ -64,12 +64,12 @@ class FriktionSDKConfig(SDKConfig):
 
     def get_otoken_details(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         offer_id: int,
         seller: str,
-        *args: Any,
         **kwargs: Any,
     ) -> OfferTokenDetails:
         """Return details about the offer token"""
@@ -84,12 +84,12 @@ class FriktionSDKConfig(SDKConfig):
 
     def get_offer_details(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         offer_id: int,
         seller: str,
-        *args: Any,
         **kwargs: Any,
     ) -> OfferDetails:
         """Return details for a given offer"""
@@ -114,13 +114,13 @@ class FriktionSDKConfig(SDKConfig):
 
     def sign_bid(
         self,
+        *,
         private_key: str,
         swap_id: int,
         signer_wallet: str,
         sell_amount: int,
         buy_amount: int,
         referrer: str,
-        *args: Any,
         **kwargs: Any,
     ) -> str:
         """Sign a bid and return the signature"""
@@ -140,6 +140,7 @@ class FriktionSDKConfig(SDKConfig):
 
     def validate_bid(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
@@ -151,7 +152,6 @@ class FriktionSDKConfig(SDKConfig):
         buy_amount: int,
         referrer: str,
         signature: str,
-        *args: Any,
         **kwargs: Any,
     ) -> BidValidation:
         """Validate the signing bid"""
@@ -180,12 +180,12 @@ class FriktionSDKConfig(SDKConfig):
 
     def verify_allowance(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         public_key: str,
         token_address: str,
-        *args: Any,
         **kwargs: Any,
     ) -> bool:
         """

--- a/opyn/opyn/config.py
+++ b/opyn/opyn/config.py
@@ -24,6 +24,7 @@ class OpynSDKConfig(SDKConfig):
 
     def create_offer(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
@@ -34,7 +35,6 @@ class OpynSDKConfig(SDKConfig):
         offer_amount: int,
         public_key: str,
         private_key: str,
-        *args: Any,
         **kwargs: Any,
     ) -> str:
         """Create an offer"""
@@ -58,10 +58,10 @@ class OpynSDKConfig(SDKConfig):
 
     def get_otoken_details(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
-        *args: Any,
         **kwargs: Any,
     ) -> OfferTokenDetails:
         """Return details about the offer token"""
@@ -74,11 +74,11 @@ class OpynSDKConfig(SDKConfig):
 
     def get_offer_details(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         offer_id: int,
-        *args: Any,
         **kwargs: Any,
     ) -> OfferDetails:
         """Return details for a given offer"""
@@ -91,6 +91,7 @@ class OpynSDKConfig(SDKConfig):
 
     def sign_bid(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         public_key: str,
@@ -101,7 +102,6 @@ class OpynSDKConfig(SDKConfig):
         sell_amount: int,
         buy_amount: int,
         referrer: str,
-        *args: Any,
         **kwargs: Any,
     ) -> str:
         """Sign a bid and return the signature"""
@@ -139,6 +139,7 @@ class OpynSDKConfig(SDKConfig):
 
     def validate_bid(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
@@ -149,7 +150,6 @@ class OpynSDKConfig(SDKConfig):
         buy_amount: int,
         referrer: str,
         signature: str,
-        *args: Any,
         **kwargs: Any,
     ) -> BidValidation:
         """Validate the signing bid"""
@@ -184,12 +184,12 @@ class OpynSDKConfig(SDKConfig):
 
     def verify_allowance(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         public_key: str,
         token_address: str,
-        *args: Any,
         **kwargs: Any,
     ) -> bool:
         """

--- a/ribbon/ribbon/config.py
+++ b/ribbon/ribbon/config.py
@@ -26,6 +26,7 @@ class RibbonSDKConfig(SDKConfig):
 
     def create_offer(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
@@ -36,7 +37,6 @@ class RibbonSDKConfig(SDKConfig):
         offer_amount: int,
         public_key: str,
         private_key: str,
-        *args: Any,
         **kwargs: Any,
     ) -> str:
         """Create an offer"""
@@ -59,7 +59,7 @@ class RibbonSDKConfig(SDKConfig):
         return swap_contract.create_offer(new_offer, wallet)
 
     def get_otoken_details(
-        self, contract_address: str, chain_id: int, rpc_uri: str, *args: Any, **kwargs: Any
+        self, *, contract_address: str, chain_id: int, rpc_uri: str, **kwargs: Any
     ) -> OfferTokenDetails:
         """Return details about the offer token"""
 
@@ -72,11 +72,11 @@ class RibbonSDKConfig(SDKConfig):
 
     def get_offer_details(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         offer_id: int,
-        *args: Any,
         **kwargs: Any,
     ) -> OfferDetails:
         """Return details for a given offer"""
@@ -90,6 +90,7 @@ class RibbonSDKConfig(SDKConfig):
 
     def sign_bid(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         public_key: str,
@@ -100,7 +101,6 @@ class RibbonSDKConfig(SDKConfig):
         sell_amount: int,
         buy_amount: int,
         referrer: str,
-        *args: Any,
         **kwargs: Any,
     ) -> str:
         """Sign a bid and return the signature"""
@@ -129,6 +129,7 @@ class RibbonSDKConfig(SDKConfig):
 
     def validate_bid(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
@@ -139,7 +140,6 @@ class RibbonSDKConfig(SDKConfig):
         buy_amount: int,
         referrer: str,
         signature: str,
-        *args: Any,
         **kwargs: Any,
     ) -> BidValidation:
         """Validate the signing bid"""
@@ -168,12 +168,12 @@ class RibbonSDKConfig(SDKConfig):
 
     def verify_allowance(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         public_key: str,
         token_address: str,
-        *args: Any,
         **kwargs: Any,
     ) -> bool:
         """

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -138,6 +138,7 @@ class SDKConfig(abc.ABC):
     @abc.abstractmethod
     def validate_bid(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -138,7 +138,6 @@ class SDKConfig(abc.ABC):
     @abc.abstractmethod
     def validate_bid(
         self,
-        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,

--- a/template/template/config.py
+++ b/template/template/config.py
@@ -21,6 +21,7 @@ class TemplateSDKConfig(SDKConfig):
 
     def create_offer(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
@@ -31,7 +32,6 @@ class TemplateSDKConfig(SDKConfig):
         offer_amount: int,
         public_key: str,
         private_key: str,
-        *args: Any,
         **kwargs: Any,
     ) -> str:
         """Create an offer"""
@@ -55,10 +55,10 @@ class TemplateSDKConfig(SDKConfig):
 
     def get_otoken_details(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
-        *args: Any,
         **kwargs: Any,
     ) -> OfferTokenDetails:
         """Return details about the offer token"""
@@ -72,11 +72,11 @@ class TemplateSDKConfig(SDKConfig):
 
     def get_offer_details(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         offer_id: int,
-        *args: Any,
         **kwargs: Any,
     ) -> OfferDetails:
         """Return details for a given offer"""
@@ -90,6 +90,7 @@ class TemplateSDKConfig(SDKConfig):
 
     def sign_bid(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         public_key: str,
@@ -100,7 +101,6 @@ class TemplateSDKConfig(SDKConfig):
         sell_amount: int,
         buy_amount: int,
         referrer: str,
-        *args: Any,
         **kwargs: Any,
     ) -> str:
         """Sign a bid and return the signature"""
@@ -120,6 +120,7 @@ class TemplateSDKConfig(SDKConfig):
 
     def validate_bid(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
@@ -130,7 +131,6 @@ class TemplateSDKConfig(SDKConfig):
         buy_amount: int,
         referrer: str,
         signature: str,
-        *args: Any,
         **kwargs: Any,
     ) -> BidValidation:
         """Validate the signing bid"""
@@ -159,12 +159,12 @@ class TemplateSDKConfig(SDKConfig):
 
     def verify_allowance(
         self,
+        *,
         contract_address: str,
         chain_id: int,
         rpc_uri: str,
         public_key: str,
         token_address: str,
-        *args: Any,
         **kwargs: Any,
     ) -> bool:
         """

--- a/tests/base.py
+++ b/tests/base.py
@@ -82,15 +82,16 @@ class TestsBase:
         method_signature = signature(method).parameters
         reference_signature = signature(reference).parameters
 
-        # All concrete implementations are expected to accept *args
+        # Concrete implementations should not accept *args because
+        # interface methods are defined to only have named parameters
         assert (
-            "args" in method_signature
-        ), f"{method.__module__}.{method.__name__} is not accepting *args parameter"
+            "args" not in method_signature
+        ), f"{method.__module__}.{method.__name__} should not accept *args parameter"
 
         # Verify that args is exactly *args
-        assert (
-            method_signature["args"].kind == Parameter.VAR_POSITIONAL
-        ), "wrong args argument, expected *args"
+        # assert (
+        #     method_signature["args"].kind == Parameter.VAR_POSITIONAL
+        # ), "wrong args argument, expected *args"
 
         # All concrete implementations are expected to accept **kwargs
         assert (

--- a/tests/base.py
+++ b/tests/base.py
@@ -88,11 +88,6 @@ class TestsBase:
             "args" not in method_signature
         ), f"{method.__module__}.{method.__name__} should not accept *args parameter"
 
-        # Verify that args is exactly *args
-        # assert (
-        #     method_signature["args"].kind == Parameter.VAR_POSITIONAL
-        # ), "wrong args argument, expected *args"
-
         # All concrete implementations are expected to accept **kwargs
         assert (
             "kwargs" in method_signature


### PR DESCRIPTION
Followup of https://github.com/tradeparadigm/sdks/pull/54:

With PR 54 we introduced introduced *args in addition to **kwargs
to fix an issue with optional parameters (see the PR for details).

But this solution was not enough to cover all extensions options,
in particular the solution allows this kind of extension at the end:

```
abstract
def func(self, a, b, c, NEW_PARAM, *args, **kwargs)
->
def func(self, a, b, c, *args, **kwargs)
```

But was not able to handle extensions in the middle:
```
abstract
def func(self, a, b, NEW_PARAM, c, *args, **kwargs)
->
def func(self, a, b, c, *args, **kwargs)
```

With https://github.com/tradeparadigm/sdks/pull/46 I silently introduced an
alternative solution by configuring all interface methods to only accept named
arguments (PEP 3102)

After some more tests I can confirm this solution and this PR cleans all
the interface to remove (again) the no longer needed  *args arguments