### PR TITLE
Update message construction and signature generation. Include swap order, pure conversion to bytes

### DIFF
--- a/friktion/friktion/bid_details.py
+++ b/friktion/friktion/bid_details.py
@@ -15,21 +15,29 @@ class BidDetails:
     bid_price: int  # 1e9
     referrer: PublicKey
 
-    def as_msg(self):
+    def as_msg(self) -> bytes:
         give_amount = self.bid_size
-        receive_amount = self.bid_price * self.bid_size
-        payload = [
-            [self.order_id],
-            str(self.signer_wallet),
-            str(self.referrer),
-            [give_amount, receive_amount],
-        ]
+        receive_amount = self.bid_price * self.bid_size * 10 ** 2
+        print("receive amount = ", receive_amount)
+        payload = bytearray()
+        payload.extend(self.order_id.to_bytes(
+            8,
+            'little',
+            signed = False
+        ))
+        payload.extend(self.signer_wallet.__bytes__())
+        payload.extend(self.referrer.__bytes__())
+        payload.extend(give_amount.to_bytes(8,'little',
+                    signed = False
+))
+        payload.extend(receive_amount.to_bytes(
+            8,'little',
+                        signed = False
 
-        # set separators to remove whitespaces
-        dumped_payload = json.dumps(payload, separators=(',', ':'))
-
-        return bytes(dumped_payload, 'utf-8')
-
+        ))
+        
+        return bytes(payload)
+ 
     def as_signed_msg(self, wallet: Wallet) -> Tuple[bytes, Signature]:
         msg_bytes = self.as_msg()
         return (msg_bytes, wallet.payer.sign(msg_bytes))

--- a/friktion/friktion/bid_details.py
+++ b/friktion/friktion/bid_details.py
@@ -6,10 +6,14 @@ from anchorpy import Wallet
 from solana.publickey import PublicKey
 from solders.signature import Signature
 
+from friktion.pda import find_swap_order_address
+
 
 @dataclass
 class BidDetails:
     signer_wallet: PublicKey
+    # necessary to verify swap order public key
+    creator: PublicKey
     order_id: int
     bid_size: int  # 1e9
     bid_price: int  # 1e9
@@ -17,16 +21,17 @@ class BidDetails:
 
     def as_msg(self) -> bytes:
         give_amount = self.bid_size
-        receive_amount = self.bid_price * self.bid_size * 10 ** 2
-        print("receive amount = ", receive_amount)
+        receive_amount = self.bid_price * self.bid_size
         payload = bytearray()
         payload.extend(self.order_id.to_bytes(
             8,
             'little',
             signed = False
         ))
+        swap_order_pk = find_swap_order_address(self.creator, self.order_id)[0]
         payload.extend(self.signer_wallet.__bytes__())
         payload.extend(self.referrer.__bytes__())
+        payload.extend(swap_order_pk.__bytes__())
         payload.extend(give_amount.to_bytes(8,'little',
                     signed = False
 ))

--- a/friktion/friktion/config.py
+++ b/friktion/friktion/config.py
@@ -2,7 +2,6 @@ import logging
 from decimal import Decimal
 from typing import Any
 
-import solders.keypair
 from anchorpy import Wallet
 from asgiref.sync import async_to_sync
 from solana.keypair import Keypair
@@ -125,9 +124,14 @@ class FriktionSDKConfig(SDKConfig):
     ) -> str:
         """Sign a bid and return the signature"""
 
+        if 'creator' not in kwargs:
+            raise Exception("Creator is required")
+
         bid = BidDetails(
             bid_size=buy_amount,
             referrer=PublicKey(referrer),
+            # TODO: replace this if necessary
+            creator=kwargs['creator'],
             bid_price=sell_amount // buy_amount,
             signer_wallet=PublicKey(signer_wallet),
             order_id=swap_id,
@@ -156,6 +160,10 @@ class FriktionSDKConfig(SDKConfig):
     ) -> BidValidation:
         """Validate the signing bid"""
 
+
+        if 'creator' not in kwargs:
+            raise Exception("Creator is required")
+
         # TODO: consider changing sdk BidDetails to receive sell amount
         # instead of bid_price to avoid the reverse computation
         bid_price = int(sell_amount / buy_amount)
@@ -163,6 +171,8 @@ class FriktionSDKConfig(SDKConfig):
             bid_price=bid_price,
             bid_size=buy_amount,
             order_id=swap_id,
+            # TODO: replace this if necessary
+            creator=kwargs['creator'],
             referrer=PublicKey(referrer),
             signer_wallet=PublicKey(signer_wallet),
         )

--- a/friktion/friktion/friktion_anchor/accounts/__init__.py
+++ b/friktion/friktion/friktion_anchor/accounts/__init__.py
@@ -1,4 +1,2 @@
-# flake8: noqa
-
-from .swap_order import SwapOrder, SwapOrderJSON
 from .user_orders import UserOrders, UserOrdersJSON
+from .swap_order import SwapOrder, SwapOrderJSON

--- a/friktion/friktion/friktion_anchor/accounts/swap_order.py
+++ b/friktion/friktion/friktion_anchor/accounts/swap_order.py
@@ -1,18 +1,16 @@
 import typing
-from base64 import b64decode
 from dataclasses import dataclass
-
-import borsh_construct as borsh
-from anchorpy.borsh_extension import BorshPubkey
-from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
-from anchorpy.error import AccountInvalidDiscriminator
-from anchorpy.utils.rpc import get_multiple_accounts
+from base64 import b64decode
 from solana.publickey import PublicKey
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment
-
-from .. import types
+import borsh_construct as borsh
+from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
+from anchorpy.error import AccountInvalidDiscriminator
+from anchorpy.utils.rpc import get_multiple_accounts
+from anchorpy.borsh_extension import BorshPubkey
 from ..program_id import PROGRAM_ID
+from .. import types
 
 
 class SwapOrderJSON(typing.TypedDict):
@@ -28,7 +26,7 @@ class SwapOrderJSON(typing.TypedDict):
     is_counterparty_provided: bool
     counterparty: str
     is_whitelisted: bool
-    whitelist_token_mint: str
+    admin: str
     is_disabled: bool
     status: types.order_status.OrderStatusJSON
     order_id: int
@@ -52,7 +50,7 @@ class SwapOrder:
         "is_counterparty_provided" / borsh.Bool,
         "counterparty" / BorshPubkey,
         "is_whitelisted" / borsh.Bool,
-        "whitelist_token_mint" / BorshPubkey,
+        "admin" / BorshPubkey,
         "is_disabled" / borsh.Bool,
         "status" / types.order_status.layout,
         "order_id" / borsh.U64,
@@ -71,7 +69,7 @@ class SwapOrder:
     is_counterparty_provided: bool
     counterparty: PublicKey
     is_whitelisted: bool
-    whitelist_token_mint: PublicKey
+    admin: PublicKey
     is_disabled: bool
     status: types.order_status.OrderStatusKind
     order_id: int
@@ -115,7 +113,9 @@ class SwapOrder:
     @classmethod
     def decode(cls, data: bytes) -> "SwapOrder":
         if data[:ACCOUNT_DISCRIMINATOR_SIZE] != cls.discriminator:
-            raise AccountInvalidDiscriminator("The discriminator for this account is invalid")
+            raise AccountInvalidDiscriminator(
+                "The discriminator for this account is invalid"
+            )
         dec = SwapOrder.layout.parse(data[ACCOUNT_DISCRIMINATOR_SIZE:])
         return cls(
             creator=dec.creator,
@@ -130,7 +130,7 @@ class SwapOrder:
             is_counterparty_provided=dec.is_counterparty_provided,
             counterparty=dec.counterparty,
             is_whitelisted=dec.is_whitelisted,
-            whitelist_token_mint=dec.whitelist_token_mint,
+            admin=dec.admin,
             is_disabled=dec.is_disabled,
             status=types.order_status.from_decoded(dec.status),
             order_id=dec.order_id,
@@ -152,7 +152,7 @@ class SwapOrder:
             "is_counterparty_provided": self.is_counterparty_provided,
             "counterparty": str(self.counterparty),
             "is_whitelisted": self.is_whitelisted,
-            "whitelist_token_mint": str(self.whitelist_token_mint),
+            "admin": str(self.admin),
             "is_disabled": self.is_disabled,
             "status": self.status.to_json(),
             "order_id": self.order_id,
@@ -175,7 +175,7 @@ class SwapOrder:
             is_counterparty_provided=obj["is_counterparty_provided"],
             counterparty=PublicKey(obj["counterparty"]),
             is_whitelisted=obj["is_whitelisted"],
-            whitelist_token_mint=PublicKey(obj["whitelist_token_mint"]),
+            admin=PublicKey(obj["admin"]),
             is_disabled=obj["is_disabled"],
             status=types.order_status.from_json(obj["status"]),
             order_id=obj["order_id"],

--- a/friktion/friktion/friktion_anchor/accounts/user_orders.py
+++ b/friktion/friktion/friktion_anchor/accounts/user_orders.py
@@ -1,16 +1,14 @@
 import typing
-from base64 import b64decode
 from dataclasses import dataclass
-
-import borsh_construct as borsh
-from anchorpy.borsh_extension import BorshPubkey
-from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
-from anchorpy.error import AccountInvalidDiscriminator
-from anchorpy.utils.rpc import get_multiple_accounts
+from base64 import b64decode
 from solana.publickey import PublicKey
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment
-
+import borsh_construct as borsh
+from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
+from anchorpy.error import AccountInvalidDiscriminator
+from anchorpy.utils.rpc import get_multiple_accounts
+from anchorpy.borsh_extension import BorshPubkey
 from ..program_id import PROGRAM_ID
 
 
@@ -22,7 +20,9 @@ class UserOrdersJSON(typing.TypedDict):
 @dataclass
 class UserOrders:
     discriminator: typing.ClassVar = b" CbS.\x05\x06\x91"
-    layout: typing.ClassVar = borsh.CStruct("user" / BorshPubkey, "curr_order_id" / borsh.U64)
+    layout: typing.ClassVar = borsh.CStruct(
+        "user" / BorshPubkey, "curr_order_id" / borsh.U64
+    )
     user: PublicKey
     curr_order_id: int
 
@@ -63,7 +63,9 @@ class UserOrders:
     @classmethod
     def decode(cls, data: bytes) -> "UserOrders":
         if data[:ACCOUNT_DISCRIMINATOR_SIZE] != cls.discriminator:
-            raise AccountInvalidDiscriminator("The discriminator for this account is invalid")
+            raise AccountInvalidDiscriminator(
+                "The discriminator for this account is invalid"
+            )
         dec = UserOrders.layout.parse(data[ACCOUNT_DISCRIMINATOR_SIZE:])
         return cls(
             user=dec.user,

--- a/friktion/friktion/friktion_anchor/errors/__init__.py
+++ b/friktion/friktion/friktion_anchor/errors/__init__.py
@@ -1,10 +1,9 @@
-import re
 import typing
-
+import re
 from solana.rpc.core import RPCException
-
 from ..program_id import PROGRAM_ID
-from . import anchor, custom
+from . import anchor
+from . import custom
 
 
 def from_code(code: int) -> typing.Union[custom.CustomError, anchor.AnchorError, None]:

--- a/friktion/friktion/friktion_anchor/errors/anchor.py
+++ b/friktion/friktion/friktion_anchor/errors/anchor.py
@@ -1,5 +1,4 @@
 import typing
-
 from anchorpy.error import ProgramError
 
 
@@ -304,7 +303,9 @@ class RequireGteViolated(ProgramError):
 
 class AccountDiscriminatorAlreadySet(ProgramError):
     def __init__(self):
-        super().__init__(3000, "The account discriminator was already set on this account")
+        super().__init__(
+            3000, "The account discriminator was already set on this account"
+        )
 
     code = 3000
     name = "AccountDiscriminatorAlreadySet"
@@ -367,7 +368,9 @@ class AccountNotMutable(ProgramError):
 
 class AccountOwnedByWrongProgram(ProgramError):
     def __init__(self):
-        super().__init__(3007, "The given account is owned by a different program than expected")
+        super().__init__(
+            3007, "The given account is owned by a different program than expected"
+        )
 
     code = 3007
     name = "AccountOwnedByWrongProgram"
@@ -412,7 +415,9 @@ class AccountNotSystemOwned(ProgramError):
 
 class AccountNotInitialized(ProgramError):
     def __init__(self):
-        super().__init__(3012, "The program expected this account to be already initialized")
+        super().__init__(
+            3012, "The program expected this account to be already initialized"
+        )
 
     code = 3012
     name = "AccountNotInitialized"
@@ -439,7 +444,9 @@ class AccountNotAssociatedTokenAccount(ProgramError):
 
 class AccountSysvarMismatch(ProgramError):
     def __init__(self):
-        super().__init__(3015, "The given public key does not match the required sysvar")
+        super().__init__(
+            3015, "The given public key does not match the required sysvar"
+        )
 
     code = 3015
     name = "AccountSysvarMismatch"
@@ -448,7 +455,9 @@ class AccountSysvarMismatch(ProgramError):
 
 class StateInvalidAddress(ProgramError):
     def __init__(self):
-        super().__init__(4000, "The given state account does not have the correct address")
+        super().__init__(
+            4000, "The given state account does not have the correct address"
+        )
 
     code = 4000
     name = "StateInvalidAddress"
@@ -457,7 +466,9 @@ class StateInvalidAddress(ProgramError):
 
 class Deprecated(ProgramError):
     def __init__(self):
-        super().__init__(5000, "The API being used is deprecated and should no longer be used")
+        super().__init__(
+            5000, "The API being used is deprecated and should no longer be used"
+        )
 
     code = 5000
     name = "Deprecated"

--- a/friktion/friktion/friktion_anchor/errors/custom.py
+++ b/friktion/friktion/friktion_anchor/errors/custom.py
@@ -1,5 +1,4 @@
 import typing
-
 from anchorpy.error import ProgramError
 
 
@@ -174,22 +173,88 @@ class InvalidSwapAdmin(ProgramError):
     msg = "invalid swap admin"
 
 
-class InvalidEd25519InstructionData(ProgramError):
+class UnableToLoadEd25519Instruction(ProgramError):
     def __init__(self) -> None:
-        super().__init__(6019, "")
+        super().__init__(6019, "unable to load instruction at currentIdx-1 position")
 
     code = 6019
+    name = "UnableToLoadEd25519Instruction"
+    msg = "unable to load instruction at currentIdx-1 position"
+
+
+class InvalidEd25519InstructionData(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6020, "invalid signature data")
+
+    code = 6020
     name = "InvalidEd25519InstructionData"
-    msg = ""
+    msg = "invalid signature data"
+
+
+class CounterpartyMismatch(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6021,
+            "mismatch between swap_order couterparty and signed message counterparty",
+        )
+
+    code = 6021
+    name = "CounterpartyMismatch"
+    msg = "mismatch between swap_order couterparty and signed message counterparty"
 
 
 class OptionAndGiveMintDontMatch(ProgramError):
     def __init__(self) -> None:
-        super().__init__(6020, "option and give mint don't match")
+        super().__init__(6022, "option and give mint don't match")
 
-    code = 6020
+    code = 6022
     name = "OptionAndGiveMintDontMatch"
     msg = "option and give mint don't match"
+
+
+class DisabledInstruction(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6023, None)
+
+    code = 6023
+    name = "DisabledInstruction"
+    msg = None
+
+
+class InvalidCounterparty(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6024, None)
+
+    code = 6024
+    name = "InvalidCounterparty"
+    msg = None
+
+
+class InvalidSigner(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6025, None)
+
+    code = 6025
+    name = "InvalidSigner"
+    msg = None
+
+
+class InvalidParam(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6026, None)
+
+    code = 6026
+    name = "InvalidParam"
+    msg = None
+
+
+class InvalidCounterpartyPool(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6027, None)
+
+    code = 6027
+    name = "InvalidCounterpartyPool"
+    msg = None
 
 
 CustomError = typing.Union[
@@ -212,8 +277,15 @@ CustomError = typing.Union[
     OrderMustBeTrading,
     InvalidEd25519Program,
     InvalidSwapAdmin,
+    UnableToLoadEd25519Instruction,
     InvalidEd25519InstructionData,
+    CounterpartyMismatch,
     OptionAndGiveMintDontMatch,
+    DisabledInstruction,
+    InvalidCounterparty,
+    InvalidSigner,
+    InvalidParam,
+    InvalidCounterpartyPool,
 ]
 CUSTOM_ERROR_MAP: dict[int, CustomError] = {
     6000: InvalidCounterParty(),
@@ -235,8 +307,15 @@ CUSTOM_ERROR_MAP: dict[int, CustomError] = {
     6016: OrderMustBeTrading(),
     6017: InvalidEd25519Program(),
     6018: InvalidSwapAdmin(),
-    6019: InvalidEd25519InstructionData(),
-    6020: OptionAndGiveMintDontMatch(),
+    6019: UnableToLoadEd25519Instruction(),
+    6020: InvalidEd25519InstructionData(),
+    6021: CounterpartyMismatch(),
+    6022: OptionAndGiveMintDontMatch(),
+    6023: DisabledInstruction(),
+    6024: InvalidCounterparty(),
+    6025: InvalidSigner(),
+    6026: InvalidParam(),
+    6027: InvalidCounterpartyPool(),
 }
 
 

--- a/friktion/friktion/friktion_anchor/instructions/__init__.py
+++ b/friktion/friktion/friktion_anchor/instructions/__init__.py
@@ -1,8 +1,6 @@
-# flake8: noqa
-
-from .cancel import CancelAccounts, cancel
-from .claim import ClaimAccounts, claim
-from .create import CreateAccounts, CreateArgs, create
-from .exec import ExecAccounts, exec
-from .exec_msg import ExecMsgAccounts, ExecMsgArgs, exec_msg
-from .set_counterparty import SetCounterpartyAccounts, set_counterparty
+from .create import create, CreateArgs, CreateAccounts
+from .exec import exec, ExecAccounts
+from .exec_msg import exec_msg, ExecMsgAccounts
+from .cancel import cancel, CancelAccounts
+from .claim import claim, ClaimAccounts
+from .set_counterparty import set_counterparty, SetCounterpartyAccounts

--- a/friktion/friktion/friktion_anchor/instructions/cancel.py
+++ b/friktion/friktion/friktion_anchor/instructions/cancel.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-
 import typing
-
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
 from ..program_id import PROGRAM_ID
 
 
@@ -20,13 +17,19 @@ class CancelAccounts(typing.TypedDict):
 
 def cancel(accounts: CancelAccounts) -> TransactionInstruction:
     keys: list[AccountMeta] = [
-        AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=True),
+        AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=False),
         AccountMeta(pubkey=accounts["swap_order"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["creator_give_pool"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["creator_give_pool"], is_signer=False, is_writable=True
+        ),
         AccountMeta(pubkey=accounts["give_pool"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["receive_pool"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["system_program"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["system_program"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b"\xe8\xdb\xdf)\xdb\xec\xdc\xbe"
     encoded_args = b""

--- a/friktion/friktion/friktion_anchor/instructions/claim.py
+++ b/friktion/friktion/friktion_anchor/instructions/claim.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-
 import typing
-
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
 from ..program_id import PROGRAM_ID
 
 
@@ -23,12 +20,20 @@ def claim(accounts: ClaimAccounts) -> TransactionInstruction:
     keys: list[AccountMeta] = [
         AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=True),
         AccountMeta(pubkey=accounts["swap_order"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["creator_give_pool"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["creator_receive_pool"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["creator_give_pool"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["creator_receive_pool"], is_signer=False, is_writable=True
+        ),
         AccountMeta(pubkey=accounts["give_pool"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["receive_pool"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["system_program"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["system_program"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b">\xc6\xd6\xc1\xd5\x9fl\xd2"
     encoded_args = b""

--- a/friktion/friktion/friktion_anchor/instructions/create.py
+++ b/friktion/friktion/friktion_anchor/instructions/create.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
-
 import typing
-
-import borsh_construct as borsh
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
+import borsh_construct as borsh
 from ..program_id import PROGRAM_ID
 
 
@@ -31,6 +28,7 @@ layout = borsh.CStruct(
 class CreateAccounts(typing.TypedDict):
     payer: PublicKey
     authority: PublicKey
+    admin: PublicKey
     user_orders: PublicKey
     swap_order: PublicKey
     give_pool: PublicKey
@@ -48,20 +46,35 @@ class CreateAccounts(typing.TypedDict):
 
 def create(args: CreateArgs, accounts: CreateAccounts) -> TransactionInstruction:
     keys: list[AccountMeta] = [
-        AccountMeta(pubkey=accounts["payer"], is_signer=False, is_writable=True),
+        AccountMeta(pubkey=accounts["payer"], is_signer=True, is_writable=True),
         AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=False),
+        AccountMeta(pubkey=accounts["admin"], is_signer=False, is_writable=False),
         AccountMeta(pubkey=accounts["user_orders"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["swap_order"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["give_pool"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["give_mint"], is_signer=False, is_writable=False),
         AccountMeta(pubkey=accounts["receive_pool"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["receive_mint"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["creator_give_pool"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["counterparty"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["whitelist_token_mint"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["options_contract"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["system_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["receive_mint"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["creator_give_pool"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["counterparty"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["whitelist_token_mint"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["options_contract"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["system_program"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
         AccountMeta(pubkey=accounts["rent"], is_signer=False, is_writable=False),
     ]
     identifier = b"\x18\x1e\xc8(\x05\x1c\x07w"

--- a/friktion/friktion/friktion_anchor/instructions/exec.py
+++ b/friktion/friktion/friktion_anchor/instructions/exec.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-
 import typing
-
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
 from ..program_id import PROGRAM_ID
 
 
@@ -31,14 +28,20 @@ def exec(accounts: ExecAccounts) -> TransactionInstruction:
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(pubkey=accounts["counterparty_give_pool"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["counterparty_give_pool"], is_signer=False, is_writable=True
+        ),
         AccountMeta(
             pubkey=accounts["whitelist_token_account"],
             is_signer=False,
             is_writable=False,
         ),
-        AccountMeta(pubkey=accounts["system_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["system_program"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b"2\x10s3\xa8z9-"
     encoded_args = b""

--- a/friktion/friktion/friktion_anchor/instructions/exec_msg.py
+++ b/friktion/friktion/friktion_anchor/instructions/exec_msg.py
@@ -1,30 +1,15 @@
 from __future__ import annotations
-
 import typing
-
-import borsh_construct as borsh
-from anchorpy.borsh_extension import BorshPubkey
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
 from ..program_id import PROGRAM_ID
-
-
-class ExecMsgArgs(typing.TypedDict):
-    signature: str
-    caller: PublicKey
-    raw_msg: str
-
-
-layout = borsh.CStruct(
-    "signature" / borsh.String, "caller" / BorshPubkey, "raw_msg" / borsh.String
-)
 
 
 class ExecMsgAccounts(typing.TypedDict):
     authority: PublicKey
     delegate_authority: PublicKey
     swap_order: PublicKey
+    counterparty_wallet: PublicKey
     give_pool: PublicKey
     receive_pool: PublicKey
     counterparty_receive_pool: PublicKey
@@ -35,11 +20,16 @@ class ExecMsgAccounts(typing.TypedDict):
     token_program: PublicKey
 
 
-def exec_msg(args: ExecMsgArgs, accounts: ExecMsgAccounts) -> TransactionInstruction:
+def exec_msg(accounts: ExecMsgAccounts) -> TransactionInstruction:
     keys: list[AccountMeta] = [
         AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=False),
-        AccountMeta(pubkey=accounts["delegate_authority"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["delegate_authority"], is_signer=False, is_writable=False
+        ),
         AccountMeta(pubkey=accounts["swap_order"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["counterparty_wallet"], is_signer=False, is_writable=False
+        ),
         AccountMeta(pubkey=accounts["give_pool"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["receive_pool"], is_signer=False, is_writable=True),
         AccountMeta(
@@ -47,23 +37,25 @@ def exec_msg(args: ExecMsgArgs, accounts: ExecMsgAccounts) -> TransactionInstruc
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(pubkey=accounts["counterparty_give_pool"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["counterparty_give_pool"], is_signer=False, is_writable=True
+        ),
         AccountMeta(
             pubkey=accounts["whitelist_token_account"],
             is_signer=False,
             is_writable=False,
         ),
-        AccountMeta(pubkey=accounts["instruction_sysvar"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["system_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["instruction_sysvar"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["system_program"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b"\xf8\x9d\x0f\xda\xc4\xb8\xf5\xb1"
-    encoded_args = layout.build(
-        {
-            "signature": args["signature"],
-            "caller": args["caller"],
-            "raw_msg": args["raw_msg"],
-        }
-    )
+    encoded_args = b""
     data = identifier + encoded_args
     return TransactionInstruction(keys, PROGRAM_ID, data)

--- a/friktion/friktion/friktion_anchor/instructions/set_counterparty.py
+++ b/friktion/friktion/friktion_anchor/instructions/set_counterparty.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-
 import typing
-
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
 from ..program_id import PROGRAM_ID
 
 
@@ -18,7 +15,9 @@ def set_counterparty(accounts: SetCounterpartyAccounts) -> TransactionInstructio
     keys: list[AccountMeta] = [
         AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=True),
         AccountMeta(pubkey=accounts["swap_order"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["counterparty"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["counterparty"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b"\xda>\xcc@\xdf\x10\\\x87"
     encoded_args = b""

--- a/friktion/friktion/friktion_anchor/types/__init__.py
+++ b/friktion/friktion/friktion_anchor/types/__init__.py
@@ -1,6 +1,3 @@
-# flake8: noqa
-
 import typing
-
 from . import order_status
-from .order_status import OrderStatusJSON, OrderStatusKind
+from .order_status import OrderStatusKind, OrderStatusJSON

--- a/friktion/friktion/friktion_anchor/types/order_status.py
+++ b/friktion/friktion/friktion_anchor/types/order_status.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
-
 import typing
 from dataclasses import dataclass
-
-import borsh_construct as borsh
 from anchorpy.borsh_extension import EnumForCodegen
+import borsh_construct as borsh
 
 
 class CreatedJSON(typing.TypedDict):
@@ -122,10 +120,7 @@ def from_json(obj: OrderStatusJSON) -> OrderStatusKind:
         return Filled()
     if obj["kind"] == "Disabled":
         return Disabled()
-
-    # This statement is unreachable, all cases of
-    # OrderStatusJSON are already verified
-    kind = obj["kind"]  # type: ignore
+    kind = obj["kind"]
     raise ValueError(f"Unrecognized enum kind: {kind}")
 
 

--- a/friktion/friktion/inertia_anchor/accounts/__init__.py
+++ b/friktion/friktion/inertia_anchor/accounts/__init__.py
@@ -1,4 +1,2 @@
-# flake8: noqa
-
 from .options_contract import OptionsContract, OptionsContractJSON
 from .stub_oracle import StubOracle, StubOracleJSON

--- a/friktion/friktion/inertia_anchor/accounts/options_contract.py
+++ b/friktion/friktion/inertia_anchor/accounts/options_contract.py
@@ -1,16 +1,14 @@
 import typing
-from base64 import b64decode
 from dataclasses import dataclass
-
-import borsh_construct as borsh
-from anchorpy.borsh_extension import BorshPubkey
-from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
-from anchorpy.error import AccountInvalidDiscriminator
-from anchorpy.utils.rpc import get_multiple_accounts
+from base64 import b64decode
 from solana.publickey import PublicKey
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment
-
+import borsh_construct as borsh
+from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
+from anchorpy.error import AccountInvalidDiscriminator
+from anchorpy.utils.rpc import get_multiple_accounts
+from anchorpy.borsh_extension import BorshPubkey
 from ..program_id import PROGRAM_ID
 
 
@@ -129,7 +127,9 @@ class OptionsContract:
     @classmethod
     def decode(cls, data: bytes) -> "OptionsContract":
         if data[:ACCOUNT_DISCRIMINATOR_SIZE] != cls.discriminator:
-            raise AccountInvalidDiscriminator("The discriminator for this account is invalid")
+            raise AccountInvalidDiscriminator(
+                "The discriminator for this account is invalid"
+            )
         dec = OptionsContract.layout.parse(data[ACCOUNT_DISCRIMINATOR_SIZE:])
         return cls(
             admin_key=dec.admin_key,

--- a/friktion/friktion/inertia_anchor/accounts/stub_oracle.py
+++ b/friktion/friktion/inertia_anchor/accounts/stub_oracle.py
@@ -1,15 +1,13 @@
 import typing
-from base64 import b64decode
 from dataclasses import dataclass
-
+from base64 import b64decode
+from solana.publickey import PublicKey
+from solana.rpc.async_api import AsyncClient
+from solana.rpc.commitment import Commitment
 import borsh_construct as borsh
 from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
 from anchorpy.error import AccountInvalidDiscriminator
 from anchorpy.utils.rpc import get_multiple_accounts
-from solana.publickey import PublicKey
-from solana.rpc.async_api import AsyncClient
-from solana.rpc.commitment import Commitment
-
 from ..program_id import PROGRAM_ID
 
 
@@ -71,7 +69,9 @@ class StubOracle:
     @classmethod
     def decode(cls, data: bytes) -> "StubOracle":
         if data[:ACCOUNT_DISCRIMINATOR_SIZE] != cls.discriminator:
-            raise AccountInvalidDiscriminator("The discriminator for this account is invalid")
+            raise AccountInvalidDiscriminator(
+                "The discriminator for this account is invalid"
+            )
         dec = StubOracle.layout.parse(data[ACCOUNT_DISCRIMINATOR_SIZE:])
         return cls(
             magic=dec.magic,

--- a/friktion/friktion/inertia_anchor/errors/__init__.py
+++ b/friktion/friktion/inertia_anchor/errors/__init__.py
@@ -1,10 +1,9 @@
-import re
 import typing
-
+import re
 from solana.rpc.core import RPCException
-
 from ..program_id import PROGRAM_ID
-from . import anchor, custom
+from . import anchor
+from . import custom
 
 
 def from_code(code: int) -> typing.Union[custom.CustomError, anchor.AnchorError, None]:

--- a/friktion/friktion/inertia_anchor/errors/anchor.py
+++ b/friktion/friktion/inertia_anchor/errors/anchor.py
@@ -1,5 +1,4 @@
 import typing
-
 from anchorpy.error import ProgramError
 
 
@@ -304,7 +303,9 @@ class RequireGteViolated(ProgramError):
 
 class AccountDiscriminatorAlreadySet(ProgramError):
     def __init__(self):
-        super().__init__(3000, "The account discriminator was already set on this account")
+        super().__init__(
+            3000, "The account discriminator was already set on this account"
+        )
 
     code = 3000
     name = "AccountDiscriminatorAlreadySet"
@@ -367,7 +368,9 @@ class AccountNotMutable(ProgramError):
 
 class AccountOwnedByWrongProgram(ProgramError):
     def __init__(self):
-        super().__init__(3007, "The given account is owned by a different program than expected")
+        super().__init__(
+            3007, "The given account is owned by a different program than expected"
+        )
 
     code = 3007
     name = "AccountOwnedByWrongProgram"
@@ -412,7 +415,9 @@ class AccountNotSystemOwned(ProgramError):
 
 class AccountNotInitialized(ProgramError):
     def __init__(self):
-        super().__init__(3012, "The program expected this account to be already initialized")
+        super().__init__(
+            3012, "The program expected this account to be already initialized"
+        )
 
     code = 3012
     name = "AccountNotInitialized"
@@ -439,7 +444,9 @@ class AccountNotAssociatedTokenAccount(ProgramError):
 
 class AccountSysvarMismatch(ProgramError):
     def __init__(self):
-        super().__init__(3015, "The given public key does not match the required sysvar")
+        super().__init__(
+            3015, "The given public key does not match the required sysvar"
+        )
 
     code = 3015
     name = "AccountSysvarMismatch"
@@ -448,7 +455,9 @@ class AccountSysvarMismatch(ProgramError):
 
 class StateInvalidAddress(ProgramError):
     def __init__(self):
-        super().__init__(4000, "The given state account does not have the correct address")
+        super().__init__(
+            4000, "The given state account does not have the correct address"
+        )
 
     code = 4000
     name = "StateInvalidAddress"
@@ -457,7 +466,9 @@ class StateInvalidAddress(ProgramError):
 
 class Deprecated(ProgramError):
     def __init__(self):
-        super().__init__(5000, "The API being used is deprecated and should no longer be used")
+        super().__init__(
+            5000, "The API being used is deprecated and should no longer be used"
+        )
 
     code = 5000
     name = "Deprecated"

--- a/friktion/friktion/inertia_anchor/errors/custom.py
+++ b/friktion/friktion/inertia_anchor/errors/custom.py
@@ -1,5 +1,4 @@
 import typing
-
 from anchorpy.error import ProgramError
 
 

--- a/friktion/friktion/inertia_anchor/instructions/__init__.py
+++ b/friktion/friktion/inertia_anchor/instructions/__init__.py
@@ -1,11 +1,13 @@
-# flake8: noqa
-
-from .close_position import ClosePositionAccounts, ClosePositionArgs, close_position
-from .create_stub_oracle import CreateStubOracleAccounts, CreateStubOracleArgs, create_stub_oracle
-from .new_contract import NewContractAccounts, NewContractArgs, new_contract
-from .option_exercise import OptionExerciseAccounts, OptionExerciseArgs, option_exercise
-from .option_redeem import OptionRedeemAccounts, OptionRedeemArgs, option_redeem
-from .option_settle import OptionSettleAccounts, OptionSettleArgs, option_settle
-from .option_write import OptionWriteAccounts, OptionWriteArgs, option_write
-from .revert_option_settle import RevertOptionSettleAccounts, revert_option_settle
-from .set_stub_oracle import SetStubOracleAccounts, SetStubOracleArgs, set_stub_oracle
+from .new_contract import new_contract, NewContractArgs, NewContractAccounts
+from .option_write import option_write, OptionWriteArgs, OptionWriteAccounts
+from .close_position import close_position, ClosePositionArgs, ClosePositionAccounts
+from .revert_option_settle import revert_option_settle, RevertOptionSettleAccounts
+from .option_settle import option_settle, OptionSettleArgs, OptionSettleAccounts
+from .option_redeem import option_redeem, OptionRedeemArgs, OptionRedeemAccounts
+from .option_exercise import option_exercise, OptionExerciseArgs, OptionExerciseAccounts
+from .create_stub_oracle import (
+    create_stub_oracle,
+    CreateStubOracleArgs,
+    CreateStubOracleAccounts,
+)
+from .set_stub_oracle import set_stub_oracle, SetStubOracleArgs, SetStubOracleAccounts

--- a/friktion/friktion/inertia_anchor/instructions/close_position.py
+++ b/friktion/friktion/inertia_anchor/instructions/close_position.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
-
 import typing
-
-import borsh_construct as borsh
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
+import borsh_construct as borsh
 from ..program_id import PROGRAM_ID
 
 
@@ -26,27 +23,35 @@ class ClosePositionAccounts(typing.TypedDict):
     underlying_token_destination: PublicKey
     underlying_pool: PublicKey
     token_program: PublicKey
-    clock: PublicKey
 
 
 def close_position(
     args: ClosePositionArgs, accounts: ClosePositionAccounts
 ) -> TransactionInstruction:
     keys: list[AccountMeta] = [
-        AccountMeta(pubkey=accounts["close_authority"], is_signer=True, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["close_authority"], is_signer=True, is_writable=False
+        ),
         AccountMeta(pubkey=accounts["contract"], is_signer=False, is_writable=False),
         AccountMeta(pubkey=accounts["writer_mint"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["option_mint"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["option_token_source"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["writer_token_source"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["option_token_source"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["writer_token_source"], is_signer=False, is_writable=True
+        ),
         AccountMeta(
             pubkey=accounts["underlying_token_destination"],
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(pubkey=accounts["underlying_pool"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["clock"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["underlying_pool"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b"{\x86Q\x001Dbb"
     encoded_args = layout.build(

--- a/friktion/friktion/inertia_anchor/instructions/create_stub_oracle.py
+++ b/friktion/friktion/inertia_anchor/instructions/create_stub_oracle.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
-
 import typing
-
-import borsh_construct as borsh
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
+import borsh_construct as borsh
 from ..program_id import PROGRAM_ID
 
 
@@ -30,7 +27,9 @@ def create_stub_oracle(
     keys: list[AccountMeta] = [
         AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=True),
         AccountMeta(pubkey=accounts["stub_oracle"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["system_program"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["system_program"], is_signer=False, is_writable=False
+        ),
         AccountMeta(pubkey=accounts["rent"], is_signer=False, is_writable=False),
     ]
     identifier = b"\x85u1\x0cx\xf4\xd8\xdb"

--- a/friktion/friktion/inertia_anchor/instructions/new_contract.py
+++ b/friktion/friktion/inertia_anchor/instructions/new_contract.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
-
 import typing
-
-import borsh_construct as borsh
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
+import borsh_construct as borsh
 from ..program_id import PROGRAM_ID
 
 
@@ -14,11 +11,6 @@ class NewContractArgs(typing.TypedDict):
     quote_amount: int
     expiry_ts: int
     is_call: int
-    contract_bump: int
-    option_bump: int
-    writer_bump: int
-    underlying_pool_bump: int
-    claimable_pool_bump: int
 
 
 layout = borsh.CStruct(
@@ -26,11 +18,6 @@ layout = borsh.CStruct(
     "quote_amount" / borsh.U64,
     "expiry_ts" / borsh.U64,
     "is_call" / borsh.U64,
-    "contract_bump" / borsh.U8,
-    "option_bump" / borsh.U8,
-    "writer_bump" / borsh.U8,
-    "underlying_pool_bump" / borsh.U8,
-    "claimable_pool_bump" / borsh.U8,
 )
 
 
@@ -52,7 +39,9 @@ class NewContractAccounts(typing.TypedDict):
     rent: PublicKey
 
 
-def new_contract(args: NewContractArgs, accounts: NewContractAccounts) -> TransactionInstruction:
+def new_contract(
+    args: NewContractArgs, accounts: NewContractAccounts
+) -> TransactionInstruction:
     keys: list[AccountMeta] = [
         AccountMeta(pubkey=accounts["payer"], is_signer=True, is_writable=True),
         AccountMeta(pubkey=accounts["admin_key"], is_signer=False, is_writable=False),
@@ -60,14 +49,28 @@ def new_contract(args: NewContractArgs, accounts: NewContractAccounts) -> Transa
         AccountMeta(pubkey=accounts["contract"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["writer_mint"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["option_mint"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["underlying_mint"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["underlying_mint"], is_signer=False, is_writable=True
+        ),
         AccountMeta(pubkey=accounts["quote_mint"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["underlying_pool"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["claimable_pool"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["mint_fee_account"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["exercise_fee_account"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["system_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["underlying_pool"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["claimable_pool"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["mint_fee_account"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["exercise_fee_account"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["system_program"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
         AccountMeta(pubkey=accounts["rent"], is_signer=False, is_writable=False),
     ]
     identifier = b'\n\xd4,"c\x7f\xc3\x8f'
@@ -77,11 +80,6 @@ def new_contract(args: NewContractArgs, accounts: NewContractAccounts) -> Transa
             "quote_amount": args["quote_amount"],
             "expiry_ts": args["expiry_ts"],
             "is_call": args["is_call"],
-            "contract_bump": args["contract_bump"],
-            "option_bump": args["option_bump"],
-            "writer_bump": args["writer_bump"],
-            "underlying_pool_bump": args["underlying_pool_bump"],
-            "claimable_pool_bump": args["claimable_pool_bump"],
         }
     )
     data = identifier + encoded_args

--- a/friktion/friktion/inertia_anchor/instructions/option_exercise.py
+++ b/friktion/friktion/inertia_anchor/instructions/option_exercise.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
-
 import typing
-
-import borsh_construct as borsh
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
+import borsh_construct as borsh
 from ..program_id import PROGRAM_ID
 
 
@@ -24,25 +21,31 @@ class OptionExerciseAccounts(typing.TypedDict):
     underlying_token_destination: PublicKey
     claimable_pool: PublicKey
     token_program: PublicKey
-    clock: PublicKey
 
 
 def option_exercise(
     args: OptionExerciseArgs, accounts: OptionExerciseAccounts
 ) -> TransactionInstruction:
     keys: list[AccountMeta] = [
-        AccountMeta(pubkey=accounts["exerciser_authority"], is_signer=True, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["exerciser_authority"], is_signer=True, is_writable=False
+        ),
         AccountMeta(pubkey=accounts["contract"], is_signer=False, is_writable=False),
         AccountMeta(pubkey=accounts["option_mint"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["option_token_source"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["option_token_source"], is_signer=False, is_writable=True
+        ),
         AccountMeta(
             pubkey=accounts["underlying_token_destination"],
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(pubkey=accounts["claimable_pool"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["clock"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["claimable_pool"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b"+V\xedN\xebJ\x83\xce"
     encoded_args = layout.build(

--- a/friktion/friktion/inertia_anchor/instructions/option_redeem.py
+++ b/friktion/friktion/inertia_anchor/instructions/option_redeem.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
-
 import typing
-
-import borsh_construct as borsh
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
+import borsh_construct as borsh
 from ..program_id import PROGRAM_ID
 
 
@@ -24,16 +21,19 @@ class OptionRedeemAccounts(typing.TypedDict):
     contract_underlying_tokens: PublicKey
     underlying_token_destination: PublicKey
     token_program: PublicKey
-    clock: PublicKey
 
 
 def option_redeem(
     args: OptionRedeemArgs, accounts: OptionRedeemAccounts
 ) -> TransactionInstruction:
     keys: list[AccountMeta] = [
-        AccountMeta(pubkey=accounts["redeemer_authority"], is_signer=True, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["redeemer_authority"], is_signer=True, is_writable=False
+        ),
         AccountMeta(pubkey=accounts["contract"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["writer_token_source"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["writer_token_source"], is_signer=False, is_writable=True
+        ),
         AccountMeta(pubkey=accounts["writer_mint"], is_signer=False, is_writable=True),
         AccountMeta(
             pubkey=accounts["contract_underlying_tokens"],
@@ -45,8 +45,9 @@ def option_redeem(
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["clock"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b"\x14\x0c\xaa\x94\x11\x81XZ"
     encoded_args = layout.build(

--- a/friktion/friktion/inertia_anchor/instructions/option_settle.py
+++ b/friktion/friktion/inertia_anchor/instructions/option_settle.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
-
 import typing
-
-import borsh_construct as borsh
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
+import borsh_construct as borsh
 from ..program_id import PROGRAM_ID
 
 
@@ -27,27 +24,33 @@ class OptionSettleAccounts(typing.TypedDict):
     claimable_pool: PublicKey
     exercise_fee_account: PublicKey
     token_program: PublicKey
-    clock: PublicKey
 
 
 def option_settle(
     args: OptionSettleArgs, accounts: OptionSettleAccounts
 ) -> TransactionInstruction:
     keys: list[AccountMeta] = [
-        AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=True),
+        AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=False),
         AccountMeta(pubkey=accounts["contract"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["oracle_ai"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["underlying_mint"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["underlying_mint"], is_signer=False, is_writable=False
+        ),
         AccountMeta(pubkey=accounts["quote_mint"], is_signer=False, is_writable=False),
         AccountMeta(
             pubkey=accounts["contract_underlying_tokens"],
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(pubkey=accounts["claimable_pool"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["exercise_fee_account"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["clock"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["claimable_pool"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["exercise_fee_account"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b"\xd4\xd9\xbc\xf1\x04\xfe=w"
     encoded_args = layout.build(

--- a/friktion/friktion/inertia_anchor/instructions/option_write.py
+++ b/friktion/friktion/inertia_anchor/instructions/option_write.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
-
 import typing
-
-import borsh_construct as borsh
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
+import borsh_construct as borsh
 from ..program_id import PROGRAM_ID
 
 
@@ -17,7 +14,7 @@ layout = borsh.CStruct("write_amount" / borsh.U64)
 
 
 class OptionWriteAccounts(typing.TypedDict):
-    writer_authority: PublicKey
+    authority: PublicKey
     contract: PublicKey
     user_underlying_funding_tokens: PublicKey
     underlying_pool: PublicKey
@@ -27,19 +24,22 @@ class OptionWriteAccounts(typing.TypedDict):
     option_mint: PublicKey
     fee_destination: PublicKey
     token_program: PublicKey
-    clock: PublicKey
 
 
-def option_write(args: OptionWriteArgs, accounts: OptionWriteAccounts) -> TransactionInstruction:
+def option_write(
+    args: OptionWriteArgs, accounts: OptionWriteAccounts
+) -> TransactionInstruction:
     keys: list[AccountMeta] = [
-        AccountMeta(pubkey=accounts["writer_authority"], is_signer=True, is_writable=True),
+        AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=False),
         AccountMeta(pubkey=accounts["contract"], is_signer=False, is_writable=False),
         AccountMeta(
             pubkey=accounts["user_underlying_funding_tokens"],
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(pubkey=accounts["underlying_pool"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["underlying_pool"], is_signer=False, is_writable=True
+        ),
         AccountMeta(
             pubkey=accounts["writer_token_destination"],
             is_signer=False,
@@ -52,9 +52,12 @@ def option_write(args: OptionWriteArgs, accounts: OptionWriteAccounts) -> Transa
         ),
         AccountMeta(pubkey=accounts["writer_mint"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["option_mint"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["fee_destination"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["clock"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["fee_destination"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b"\xbd#\xdc\x18\xe0_r\x1b"
     encoded_args = layout.build(

--- a/friktion/friktion/inertia_anchor/instructions/revert_option_settle.py
+++ b/friktion/friktion/inertia_anchor/instructions/revert_option_settle.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-
 import typing
-
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
 from ..program_id import PROGRAM_ID
 
 
@@ -18,27 +15,33 @@ class RevertOptionSettleAccounts(typing.TypedDict):
     claimable_pool: PublicKey
     exercise_fee_account: PublicKey
     token_program: PublicKey
-    clock: PublicKey
 
 
 def revert_option_settle(
     accounts: RevertOptionSettleAccounts,
 ) -> TransactionInstruction:
     keys: list[AccountMeta] = [
-        AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=True),
+        AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=False),
         AccountMeta(pubkey=accounts["contract"], is_signer=False, is_writable=True),
         AccountMeta(pubkey=accounts["oracle_ai"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["underlying_mint"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["underlying_mint"], is_signer=False, is_writable=False
+        ),
         AccountMeta(pubkey=accounts["quote_mint"], is_signer=False, is_writable=False),
         AccountMeta(
             pubkey=accounts["contract_underlying_tokens"],
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(pubkey=accounts["claimable_pool"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["exercise_fee_account"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["token_program"], is_signer=False, is_writable=False),
-        AccountMeta(pubkey=accounts["clock"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["claimable_pool"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["exercise_fee_account"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["token_program"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b"\xe5\xf0\xd6\x84j\xac*\x9f"
     encoded_args = b""

--- a/friktion/friktion/inertia_anchor/instructions/set_stub_oracle.py
+++ b/friktion/friktion/inertia_anchor/instructions/set_stub_oracle.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
-
 import typing
-
-import borsh_construct as borsh
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
-
+from solana.transaction import TransactionInstruction, AccountMeta
+import borsh_construct as borsh
 from ..program_id import PROGRAM_ID
 
 
@@ -28,7 +25,9 @@ def set_stub_oracle(
     keys: list[AccountMeta] = [
         AccountMeta(pubkey=accounts["authority"], is_signer=True, is_writable=False),
         AccountMeta(pubkey=accounts["stub_oracle"], is_signer=False, is_writable=True),
-        AccountMeta(pubkey=accounts["system_program"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["system_program"], is_signer=False, is_writable=False
+        ),
     ]
     identifier = b"\x95E\x02\x84\x8b\x89\xde\x1b"
     encoded_args = layout.build(

--- a/friktion/friktion/swap.py
+++ b/friktion/friktion/swap.py
@@ -38,6 +38,7 @@ from .friktion_anchor.instructions import create, exec, exec_msg
 from .swap_order_template import SwapOrderTemplate
 
 GLOBAL_FRIKTION_AUTHORITY = PublicKey("7wYqGsQmfVigMSratssoPddfLU1P5srZcM32nvKAgWkj")
+GLOBAL_FRIKTION_ADMIN = PublicKey("DxMJgeSVoe1cWo1NPExiAsmn83N3bADvkT86dSP1k7WE")
 
 
 def get_token_account(token_account_pk: PublicKey):
@@ -279,6 +280,7 @@ class SwapContract:
             {
                 "payer": wallet.public_key,  # signer
                 "authority": wallet.public_key,
+                "admin": GLOBAL_FRIKTION_ADMIN,
                 "user_orders": pdas.user_orders_address,
                 "swap_order": pdas.swap_order_address,
                 "give_pool": pdas.give_pool_address,
@@ -338,15 +340,11 @@ class SwapContract:
         )
 
         ix = exec_msg(
+   
             {
-                # "signature": str(signature.to_json()),
-                "signature": str(bid_details.as_msg()),
-                "caller": bid_details.signer_wallet,
-                "raw_msg": signature,
-            },
-            {
-                "authority": bid_details.signer_wallet,
+                "authority": tx_sender_wallet.public_key,
                 "delegate_authority": DELEGATE_AUTHORITY_ADDRESS,
+                "counterparty_wallet": bid_details.signer_wallet,
                 "swap_order": swap_order_address,
                 "give_pool": swap_order.give_pool,
                 "receive_pool": swap_order.receive_pool,

--- a/friktion/main.py
+++ b/friktion/main.py
@@ -43,6 +43,19 @@ REFERRER = wallet.public_key
 
 async def main_def():
 
+    # example of signing
+    # print('counterparty = ' , COUNTERPARTY)
+    # bid_details = BidDetails(
+    #     bid_price=1, bid_size=100000000, order_id=0, signer_wallet=COUNTERPARTY, referrer=REFERRER
+    # )
+
+    # # happens outside of paradigm
+    # (msg, signature) = bid_details.as_signed_msg(wallet)
+    # print()
+    # print(msg)
+    # print('bytes = ', [b for b in msg])
+    # print(signature)
+
     client = AsyncClient(c.url)
     await client.is_connected()
 

--- a/friktion/tests/helpers.py
+++ b/friktion/tests/helpers.py
@@ -90,6 +90,7 @@ if __name__ == "__main__":
         bid_price=500000,
         bid_size=10,
         order_id=22,
+        creator=wallet.public_key,
         referrer=PublicKey('7yeeGWxusjqvjYGMSXuyYAdjqr13rJVL9WK2f2u7KbWV'),
         signer_wallet=PublicKey('7yeeGWxusjqvjYGMSXuyYAdjqr13rJVL9WK2f2u7KbWV'),
     )


### PR DESCRIPTION
Hi, this PR fixes a few of the signature errors I ran into during testing. I was able to succesfully execute the auction after modification. Once these changes are live, I believe the auction process will be quite smooth. Please see vrfq auction ID 379 for an example of a completed auction. I am adding the Creator public key to BidDetails in order to allow derivation of the swap order public key. This is important to verify the message is being signed for a specific swap order while verifying contract-side, and was an oversight from earlier.