### PR TITLE
Bump flake8 to 6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,10 @@ repos:
   hooks:
   - id: isort
     args: [--sp=pyproject.toml]
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 4.0.1
+- repo: https://github.com/pycqa/flake8
+  rev: 6.0.0
   hooks:
-  - id: flake8
+    - id: flake8
 - repo: https://github.com/igorshubovych/markdownlint-cli
   rev: v0.32.2
   hooks:


### PR DESCRIPTION
Gitlab repository for the flake8 precommit hook is not longer available
and it is now moved to github. In addition, bump flake8 version to 6.0.0