### PR TITLE
Fix Thetanuts get_otoken_details by temporary introducing new swap param

### DIFF
--- a/ribbon/ribbon/config.py
+++ b/ribbon/ribbon/config.py
@@ -59,7 +59,13 @@ class RibbonSDKConfig(SDKConfig):
         return swap_contract.create_offer(new_offer, wallet)
 
     def get_otoken_details(
-        self, *, contract_address: str, chain_id: int, rpc_uri: str, **kwargs: Any
+        self,
+        *,
+        # TODO: to be renamed into token_address
+        contract_address: str,
+        chain_id: int,
+        rpc_uri: str,
+        **kwargs: Any,
     ) -> OfferTokenDetails:
         """Return details about the offer token"""
 

--- a/sdk_commons/sdk_commons/config.py
+++ b/sdk_commons/sdk_commons/config.py
@@ -93,7 +93,10 @@ class SDKConfig(abc.ABC):
     def get_otoken_details(
         self,
         *,
+        # TODO: to be renamed into token_address
         contract_address: str,
+        # TODO: to be normalized with the other methods
+        swap_contract_address: str,
         chain_id: int,
         rpc_uri: str,
         offer_id: int,

--- a/thetanuts/thetanuts/config.py
+++ b/thetanuts/thetanuts/config.py
@@ -122,7 +122,10 @@ class Thetanuts(SDKConfig):
     def get_otoken_details(
         self,
         *,
+        # TODO: to be renamed into token_address
         contract_address: str,
+        # TODO: to be normalized with the other methods
+        swap_contract_address: str,
         chain_id: int,
         rpc_uri: str,
         **kwargs: Any,
@@ -131,11 +134,11 @@ class Thetanuts(SDKConfig):
 
         w3 = web3.Web3(web3.HTTPProvider(rpc_uri))
         bridgeContract = w3.eth.contract(
-            w3.toChecksumAddress(contract_address),
+            w3.toChecksumAddress(swap_contract_address),
             abi=get_abi("Thetanuts_ParadigmBridge"),
         )
 
-        aucDetails = bridgeContract.functions.getAuctionDetails(kwargs["oToken"]).call()
+        aucDetails = bridgeContract.functions.getAuctionDetails(contract_address).call()
 
         return {
             "collateralAsset": aucDetails[0],


### PR DESCRIPTION
`get_otoken_details` takes as input a misleading `contract_address`
parameter used to send the token address to the method. This parameter
should be renamed into a more clear `token_address` and `contract_address`
should be used for the swap address (now required by Thetanuts).
Unfortunately at the moment we can't introduce this breaking change, so
as a temporary workaround we decided to introduce a new
`swap_contract_address` parameter and keep `contract_address` as it is.
In a next followup these names will be normalized.