### PR TITLE
[ribbon] Fix contract abi location to avoid hardcoded Swap ABI

### DIFF
--- a/ribbon/ribbon/contract.py
+++ b/ribbon/ribbon/contract.py
@@ -14,7 +14,7 @@ from web3.middleware import geth_poa_middleware
 from ribbon.definitions import ContractConfig
 from ribbon.utils import get_address
 from sdk_commons.chains import Chains
-from sdk_commons.helpers import get_abi
+from sdk_commons.helpers import get_abi, get_abi_path
 
 
 # ---------------------------------------------------------------------------
@@ -34,6 +34,8 @@ class ContractConnection:
         w3 (object): RPC connection instance
         contract (object): Contract instance
     """
+
+    abi_location = get_abi_path("Ribbon_Swap")
 
     def __init__(self, config: ContractConfig):
         # Can't be imported on top due to a circular dependency
@@ -61,6 +63,6 @@ class ContractConnection:
         if chain == Chains.FUJI:
             self.w3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
-        abi = get_abi('Ribbon_Swap')
+        abi = get_abi(self.abi_location)
 
         self.contract = self.w3.eth.contract(self.address, abi=abi)

--- a/sdk_commons/sdk_commons/helpers.py
+++ b/sdk_commons/sdk_commons/helpers.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 EVM_SIGNATURE_LEN = 130
 
@@ -16,14 +16,16 @@ def get_evm_signature_components(signature: str) -> tuple[str, str, int]:
     return r, s, v
 
 
-def get_abi_path(abi_name: str) -> Path:
+def get_abi_path(abi_name: Union[str, Path]) -> Path:
     """
     Resolve an abi name to the absolute path of the abi json
     """
+    if isinstance(abi_name, Path):
+        return abi_name
     return Path(__file__).parent.joinpath('abis', abi_name).with_suffix('.json')
 
 
-def get_abi(abi_name: str) -> Any:
+def get_abi(abi_name: Union[str, Path]) -> Any:
     """
     Resolve an abi name to the content of the abi json
     """


### PR DESCRIPTION
In a previous commit we move all ABIs to a shared folder, but with this
change we hardcoded the swap contract ABI. As a result we introduced a
bug causing the otoken contract ABI to be ignored.
