### PR TITLE
Merge Web3 and ETH upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,25 @@
   "pre-commit": {
     "enabled": true,
     "groupName": "pre-commit"
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Group together WEB3 and all ETH packages",
+      "groupName": "WEB3 and ETH dependencies",
+      "matchManagers": [
+        "pip_requirements",
+      ],
+      "matchPackageNames": [
+        "eth-abi",
+        "eth-account",
+        "eth-hash",
+        "eth-keyfile",
+        "eth-keys",
+        "eth-rlp",
+        "eth-typing",
+        "eth-utils",
+        "web3"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Having strict relationships it's easier to merge these dependencies
together to test the bump more easily and prevent failures due to
unsatisfied intra-dependencies