### PR TITLE
Add poetry manager to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,7 @@
       "groupName": "WEB3 and ETH dependencies",
       "matchManagers": [
         "pip_requirements",
+        "poetry"
       ],
       "matchPackageNames": [
         "eth-abi",


### PR DESCRIPTION
Renovate recognizes our dependencies with the poetry manager, being
listed in the pyproject.toml