### PR TITLE
Introduce pyupgrade and apply python 3.10 syntax changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,11 @@ repos:
   rev: 6.0.0
   hooks:
     - id: flake8
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.3.1
+  hooks:
+    - id: pyupgrade
+      args: [--py310-plus]
 - repo: https://github.com/igorshubovych/markdownlint-cli
   rev: v0.33.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'poetry.core.masonry.api'
 name = 'sdks'
 description = 'Paradigm SDK to interact with DeFi Venues'
 license = 'MIT'
-version = '0.5.1'
+version = '0.5.2'
 authors = [
     "Paolo D'Onorio De Meo <paolo@paradigm.co>",
     "Cássios Marques <cassios@paradigm.co>",

--- a/ribbon/ribbon/config.py
+++ b/ribbon/ribbon/config.py
@@ -15,7 +15,6 @@ class AuthorizationPages:
 
 
 class RibbonSDKConfig(SDKConfig):
-
     authorization_pages = AuthorizationPages
     supported_chains = [
         Chains.AVALANCHE,

--- a/ribbon/ribbon/contract.py
+++ b/ribbon/ribbon/contract.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
 # Created By: Steven@Ribbon, Paolo@Paradigm
 # Created Date: 04/04/2022

--- a/ribbon/ribbon/definitions.py
+++ b/ribbon/ribbon/definitions.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
 # Created By: Steven@Ribbon, Paolo@Paradigm
 # Created Date: 04/04/2022
@@ -12,7 +11,6 @@
 # Imports
 # ---------------------------------------------------------------------------
 from dataclasses import dataclass
-from typing import Optional
 
 from ribbon.encode import ADDRESS_ZERO
 from sdk_commons.chains import Chains
@@ -36,7 +34,7 @@ class Domain:
     chainId: int
     verifyingContract: str
     version: str
-    salt: Optional[str] = None
+    salt: str | None = None
 
 
 @dataclass
@@ -51,9 +49,9 @@ class Bid:
 
 @dataclass
 class SignedBid(Bid):
-    v: Optional[int] = None
-    r: Optional[str] = None
-    s: Optional[str] = None
+    v: int | None = None
+    r: str | None = None
+    s: str | None = None
 
 
 @dataclass

--- a/ribbon/ribbon/encode.py
+++ b/ribbon/ribbon/encode.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
 # Created By: Steven@Ribbon
 # Created Date: 04/04/2022
@@ -9,7 +8,8 @@
 # ---------------------------------------------------------------------------
 
 import re
-from typing import Any, Callable, Optional, cast
+from collections.abc import Callable
+from typing import Any, cast
 
 # ---------------------------------------------------------------------------
 # Imports
@@ -51,7 +51,7 @@ def uint_encoder(data_type: str) -> EncoderType:
     Returns:
         encoder (EncoderType): Uint encoder
     """
-    match = re.findall('^(u?)int(\d*)$', data_type).pop()
+    match = re.findall(r'^(u?)int(\d*)$', data_type).pop()
     signed = match[1] == ''
     width = int(match[2]) if len(match) == 3 else 256
 
@@ -83,7 +83,7 @@ def bytes_encoder(data_type: str) -> EncoderType:
     Returns:
         encoder (EncoderType): Bytes encoder
     """
-    match = re.findall('^bytes(\d+)$', data_type).pop()
+    match = re.findall(r'^bytes(\d+)$', data_type).pop()
     width = int(match[1])
 
     if width == 0 or width > 32 or match[1] != str(width):
@@ -102,7 +102,7 @@ def bytes_encoder(data_type: str) -> EncoderType:
     )
 
 
-def get_base_encoder(data_type: str) -> Optional[EncoderType]:
+def get_base_encoder(data_type: str) -> EncoderType | None:
     """
     Get the encoder for base types
 
@@ -112,9 +112,9 @@ def get_base_encoder(data_type: str) -> Optional[EncoderType]:
     Returns:
         encoder (EncoderType): Encoder
     """
-    if re.match('^(u?)int(\d*)$', data_type):
+    if re.match(r'^(u?)int(\d*)$', data_type):
         return uint_encoder(data_type)
-    elif re.match('^bytes(\d+)$', data_type):
+    elif re.match(r'^bytes(\d+)$', data_type):
         return bytes_encoder(data_type)
     elif data_type == 'address':
         return lambda value: hex_zero_pad(get_address(value), 32)
@@ -154,7 +154,6 @@ class TypedDataEncoder:
         self.subtypes: dict[str, dict[str, bool]] = {}
 
         for name in types:
-
             self.links.setdefault(name, {})
             self.parents.setdefault(name, [])
             self.subtypes.setdefault(name, {})
@@ -169,7 +168,7 @@ class TypedDataEncoder:
 
                 uniqueNames[fieldName] = True
 
-                baseType = re.sub('\[[^()]*\]', '', field['type'])
+                baseType = re.sub(r'\[[^()]*\]', '', field['type'])
 
                 if baseType == name:
                     raise ValueError(f'Circular type reference: {baseType}')
@@ -214,7 +213,7 @@ class TypedDataEncoder:
                 [encode_type(t, types[t]) for t in st]
             )
 
-    def _get_encoder(self, data_type: str) -> Optional[EncoderType]:
+    def _get_encoder(self, data_type: str) -> EncoderType | None:
         """
         Get the encoder for a given type
 
@@ -227,13 +226,12 @@ class TypedDataEncoder:
         if encoder := get_base_encoder(data_type):
             return encoder
 
-        match = re.findall('\[[^()]*\]', data_type)
+        match = re.findall(r'\[[^()]*\]', data_type)
         if len(match) > 0:
             match = data_type[:-1].split('[')
             subtype = match[0]
             subEncoder = self.get_encoder(subtype)
             length = 0 if len(match) == 1 else int(match[1])
-            # print(length)
             return cast(
                 EncoderType,
                 (

--- a/ribbon/ribbon/erc20.py
+++ b/ribbon/ribbon/erc20.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
 # Created By: Steven@Ribbon, Paolo@Paradigm
 # Created Date: 08/04/2022
@@ -8,7 +7,7 @@
 """ Module to interact with ERC20 contracts """
 # ---------------------------------------------------------------------------
 
-from typing import Optional, cast
+from typing import cast
 
 # ---------------------------------------------------------------------------
 # Imports
@@ -39,7 +38,7 @@ class ERC20Contract(ContractConnection):
         # TODO: Which is the correct type here? int? Decimal? float?
         self.decimals = cast(float, self.contract.functions.decimals().call())
 
-    def get_allowance(self, owner: Optional[str], spender: str) -> int:
+    def get_allowance(self, owner: str | None, spender: str) -> int:
         """
         Method to get allowance of owner
 

--- a/ribbon/ribbon/otoken.py
+++ b/ribbon/ribbon/otoken.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
 # Created By: Steven@Ribbon, Paolo@Paradigm
 # Created Date: 04/04/2022

--- a/ribbon/ribbon/swap.py
+++ b/ribbon/ribbon/swap.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
 # Created By: Steven@Ribbon, Paolo@Paradigm
 # Created Date: 04/04/2022

--- a/ribbon/ribbon/utils.py
+++ b/ribbon/ribbon/utils.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
 # Created By: Steven@Ribbon
 # Created Date: 04/04/2022
@@ -9,7 +8,6 @@
 # ---------------------------------------------------------------------------
 
 import re
-from typing import Optional
 
 from eth_typing import ChecksumAddress
 from web3 import Web3
@@ -40,7 +38,7 @@ def id(text: str) -> str:
     return Web3.keccak(text=text).hex()
 
 
-def get_address(address: Optional[str]) -> ChecksumAddress:
+def get_address(address: str | None) -> ChecksumAddress:
     """
     Validate address validity and return the checksum address
 

--- a/ribbon/ribbon/wallet.py
+++ b/ribbon/ribbon/wallet.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
 # Created By: Steven@Ribbon, Paolo@Paradigm
 # Created Date: 04/04/2022

--- a/sdk_commons/sdk_commons/helpers.py
+++ b/sdk_commons/sdk_commons/helpers.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 EVM_SIGNATURE_LEN = 130
 
@@ -16,7 +16,7 @@ def get_evm_signature_components(signature: str) -> tuple[str, str, int]:
     return r, s, v
 
 
-def get_abi_path(abi_name: Union[str, Path]) -> Path:
+def get_abi_path(abi_name: str | Path) -> Path:
     """
     Resolve an abi name to the absolute path of the abi json
     """
@@ -25,7 +25,7 @@ def get_abi_path(abi_name: Union[str, Path]) -> Path:
     return Path(__file__).parent.joinpath('abis', abi_name).with_suffix('.json')
 
 
-def get_abi(abi_name: Union[str, Path]) -> Any:
+def get_abi(abi_name: str | Path) -> Any:
     """
     Resolve an abi name to the content of the abi json
     """

--- a/template/template/config.py
+++ b/template/template/config.py
@@ -15,7 +15,6 @@ class AuthorizationPages:
 
 
 class TemplateSDKConfig(SDKConfig):
-
     authorization_pages = AuthorizationPages
     supported_chains = [Chains.ROPSTEN, Chains.KOVAN]
 

--- a/template/template/definitions.py
+++ b/template/template/definitions.py
@@ -1,6 +1,5 @@
 """ Module to store data classes """
 from dataclasses import dataclass
-from typing import Optional
 
 from sdk_commons.chains import Chains
 
@@ -53,6 +52,6 @@ class SignedBid:
     sellAmount: int
     buyAmount: int
     referrer: str
-    v: Optional[int] = None
-    r: Optional[str] = None
-    s: Optional[str] = None
+    v: int | None = None
+    r: str | None = None
+    s: str | None = None

--- a/thetanuts/thetanuts/config.py
+++ b/thetanuts/thetanuts/config.py
@@ -19,7 +19,6 @@ class AuthorizationPages:
 
 
 class Thetanuts(SDKConfig):
-
     authorization_pages = AuthorizationPages
     supported_chains = [Chains.ETHEREUM, Chains.MATIC]
 

--- a/thetanuts/thetanuts_test.py
+++ b/thetanuts/thetanuts_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
 # Created By: Pecan@Thetanuts
 # Created Date: 13/10/2022


### PR DESCRIPTION
Introduce a `pyupgrade` `pre-commit` hook to automatically upgrade the
python syntax to the supported python version (3.10), apply all
suggested upgrades.