### PR TITLE
Fix eth_abi deprecation warning

### DIFF
--- a/thetanuts/thetanuts/wallet.py
+++ b/thetanuts/thetanuts/wallet.py
@@ -1,7 +1,7 @@
 """ Module for wallet utilities """
 import eth_keys  # type: ignore
 import web3
-from eth_abi.packed import encode_abi_packed
+from eth_abi.packed import encode_packed
 from eth_account.messages import encode_defunct
 from web3 import Web3
 
@@ -64,7 +64,7 @@ class Wallet:
         if signerWallet != self.public_key:
             raise ValueError("Signer wallet address mismatch")
 
-        toSign = encode_abi_packed(
+        toSign = encode_packed(
             ['address', 'uint', 'uint', 'address'],
             [
                 bid.vaultAddress,


### PR DESCRIPTION
`eth_abi` v3 deprecated `encode_abi_packed` in favor of `encode_packed`.

```
DeprecationWarning: abi.encode_abi() and abi.encode_abi_packed() are
deprecated and will be removed in version 4.0.0 in favor of abi.encode
() and abi.encode_packed(), respectively
```
