### PR TITLE
Parameterise transactions (priority_fee, max_fee) for Thetanuts

### DIFF
--- a/thetanuts/thetanuts/config.py
+++ b/thetanuts/thetanuts/config.py
@@ -22,6 +22,7 @@ class Thetanuts(SDKConfig):
     authorization_pages = AuthorizationPages
     supported_chains = [Chains.ETHEREUM, Chains.MATIC]
     PARADIGM_OFFSET = 100  # Bridge returns 1e6, Paradigm expects 1e8
+    PRIORITY_FEE = {Chains.ETHEREUM: hex(int(1e8)), Chains.MATIC: hex(int(30e9))}
 
     def create_offer(
         self,
@@ -55,7 +56,12 @@ class Thetanuts(SDKConfig):
             tx = w3.eth.send_raw_transaction(
                 w3.eth.account.sign_transaction(
                     vaultContract.functions.setExpiry(currentTime).build_transaction(
-                        {'nonce': Nonce(nonce), 'from': public_key}
+                        {
+                            'nonce': Nonce(nonce),
+                            'from': public_key,
+                            'maxPriorityFeePerGas': self.PRIORITY_FEE[chain_id],
+                            'maxFeePerGas': hex(w3.eth.gas_price * 2),
+                        }
                     ),
                     private_key,
                 ).rawTransaction
@@ -66,7 +72,12 @@ class Thetanuts(SDKConfig):
             tx = w3.eth.send_raw_transaction(
                 w3.eth.account.sign_transaction(
                     vaultContract.functions.settleStrike_MM(int(1000e6)).build_transaction(
-                        {'nonce': Nonce(nonce + 1), 'from': public_key}
+                        {
+                            'nonce': Nonce(nonce + 1),
+                            'from': public_key,
+                            'maxPriorityFeePerGas': self.PRIORITY_FEE[chain_id],
+                            'maxFeePerGas': hex(w3.eth.gas_price * 2),
+                        }
                     ),
                     private_key,
                 ).rawTransaction
@@ -114,7 +125,13 @@ class Thetanuts(SDKConfig):
                     bridgeContract.functions.setNextStrikeAndSize(
                         oToken, int(price), amtToSell
                     ).build_transaction(
-                        {'nonce': Nonce(nonce), 'from': public_key, "gas": 200000}
+                        {
+                            'nonce': Nonce(nonce),
+                            'from': public_key,
+                            "gas": 200000,
+                            "maxPriorityFeePerGas": self.PRIORITY_FEE[chain_id],
+                            'maxFeePerGas': hex(w3.eth.gas_price * 2),
+                        }
                     ),
                     private_key,
                 ).rawTransaction

--- a/thetanuts/thetanuts_test.py
+++ b/thetanuts/thetanuts_test.py
@@ -28,6 +28,7 @@ def get_env(variable: str) -> str:
 
 current_chain = Chains.MATIC
 rpc_uri = "https://polygon-rpc.com"
+PRIORITY_FEE = {Chains.ETHEREUM: hex(int(1e8)), Chains.MATIC: hex(int(30e9))}
 
 w3 = web3.Web3(web3.HTTPProvider(rpc_uri))
 if current_chain == Chains.MATIC:
@@ -216,7 +217,14 @@ tx = bridgeContract.functions.pullAssetsAndStartRound(
     int(vaultInfo["expiryTimestamp"]),
     maker_public,
     signed_bid,
-).build_transaction({'nonce': w3.eth.get_transaction_count(owner_public), 'from': owner_public})
+).build_transaction(
+    {
+        'nonce': w3.eth.get_transaction_count(owner_public),
+        'from': owner_public,
+        'maxPriorityFeePerGas': PRIORITY_FEE[current_chain],
+        'maxFeePerGas': hex(w3.eth.gas_price * 2),
+    }
+)
 signedTx = w3.eth.send_raw_transaction(
     w3.eth.account.sign_transaction(tx, owner_private).rawTransaction
 )
@@ -360,7 +368,14 @@ tx = bridgeContract.functions.pullAssetsAndStartRound(
     int(vaultInfo["expiryTimestamp"]),
     maker_public,
     signed_bid,
-).build_transaction({'nonce': w3.eth.get_transaction_count(owner_public), 'from': owner_public})
+).build_transaction(
+    {
+        'nonce': w3.eth.get_transaction_count(owner_public),
+        'from': owner_public,
+        'maxPriorityFeePerGas': PRIORITY_FEE[current_chain],
+        'maxFeePerGas': hex(w3.eth.gas_price * 2),
+    }
+)
 signedTx = w3.eth.send_raw_transaction(
     w3.eth.account.sign_transaction(tx, owner_private).rawTransaction
 )


### PR DESCRIPTION
Web3.py sometimes suggest priority_fee that falls below 30 gwei for Polygon/MATIC; however, only a small subset of validators will accept a min priority fee below 30 gwei. 

When this happens, the transaction stalls until a validator accepts the transaction.

This makes running thetanuts_test.py rather trying sometimes, as the transaction will timeout.

Code is updated to use 30 gwei as priority_fee on Polygon, and 0.1 gwei on Ethereum mainnet.