### PR TITLE
Bump sdks to 0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'poetry.core.masonry.api'
 name = 'sdks'
 description = 'Paradigm SDK to interact with DeFi Venues'
 license = 'MIT'
-version = '0.8.0'
+version = '0.8.1'
 authors = [
     "Paolo D'Onorio De Meo <paolo@paradigm.co>",
     "Cássios Marques <cassios@paradigm.co>",


### PR DESCRIPTION
New version to include
- [[thetanuts] Ensure signature is prepended by '0x' in validate_bid](https://github.com/tradeparadigm/sdks/commit/ff5802fe459a01faaa6658cef45397788d3e1cb3)
- [Bump python max version](https://github.com/tradeparadigm/sdks/commit/3806c4b7b6846d149301161113fdeb2a5bb418ea)