### PR TITLE
Update Python max version <3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = '>=3.7.2,<=3.11'
+python = '>=3.7.2,<3.12'
 
 # Shared Ribbon & Thetanuts
 eth-abi = '4.0.0'


### PR DESCRIPTION
Unfortunately, the previous update `>=3.11` does not satisfy `3.11.3`, so this switches to `<3.12`