### PR TITLE
Add PEP 561 markers

### DIFF
--- a/ribbon/ribbon/py.typed
+++ b/ribbon/ribbon/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The ribbon package uses inline types.

--- a/template/template/py.typed
+++ b/template/template/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The template package uses inline types.

--- a/thetanuts/thetanuts/py.typed
+++ b/thetanuts/thetanuts/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The thetanuts package uses inline types.


### PR DESCRIPTION
Based on [PEP 561] specifications, a `py.typed`  marker file is needed
to allow tools like mypy to use the inline type annotations.

[PEP 561]: https://peps.python.org/pep-0561/