### PR TITLE
Enable Renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,10 @@
   "commitMessageTopic": "{{depName}}",
   "commitMessageExtra": "to {{newVersion}}",
   "transitiveRemediation": true,
+  "automerge": true,
+  "automergeStrategy": "squash",
+  "rebaseWhen": "conflict",
+  "assignAutomerge": true,
   "vulnerabilityAlerts": {
     "labels": [
       "dependencies",


### PR DESCRIPTION
To speedup bumping process this commit enables Renovate automerge.
Please note that PR approval is still needed to allow Renovate to merge.
In addition it is configured to rebase the PR in case of conflicts
before merging, and to force reviewers assignment (otherwise Renovate
does not assign reviewers and assignees to automerge-enabled PR at
creation time, but only in case it fails status checks).